### PR TITLE
fixing error in float specialization

### DIFF
--- a/src/casts/interpret-casts-common.rkt
+++ b/src/casts/interpret-casts-common.rkt
@@ -1382,7 +1382,7 @@ TODO write unit tests
       (match t2
         [(Type (Dyn))
          (error 'grift/make-code-gen-project "Called with t2 = Dyn")]
-        [(Type (or (Float) (Int) (Character) (Unit) (Bool)))
+        [(Type (or (Int) (Character) (Unit) (Bool)))
          (If (dyn-immediate-tag=?$ v t2)
              (dyn-immediate-value$ v)
              (interp-project v t2 l mt))]

--- a/tests/suite/core/float1.schml
+++ b/tests/suite/core/float1.schml
@@ -1,0 +1,5 @@
+(define f : Float 1.5)
+(define d : Dyn f)
+(if (fl= f d)
+    #t
+    #f)

--- a/tests/suite/core/tests.rkt
+++ b/tests/suite/core/tests.rkt
@@ -19,6 +19,7 @@
    (test-file "core" "const-negative.schml" (int -5))
    (test-file "core" "const-ninetynine.schml" (int 99))
    (test-file "core" "const-larg-int.schml" (int 123456))
+   ;; Character
    (test-file "core" "const-char-a.schml" (char #\a))
    (test-file "core" "const-char-null.schml" (char #\nul))
    (test-file "core" "let-const-char-z.schml" (char #\z))
@@ -76,6 +77,8 @@
    "core tests"
    #:before (lambda () (display "core test running ... "))
    #:after (lambda () (display "done\n"))
+   ;; Simple dynamic tests
+   (test-file "core" "float1.schml" (bool #t))
    ;; Let
    (test-file "core" "let10.schml" (dyn))
    (test-file "core" "let12.1.schml" (dyn))


### PR DESCRIPTION
Float specialization is currently broken resulting in incorrect floating point numbers after projecting from dynamic. 

This pull request:
- fixes the problem
- adds minimal test case
- changes the test suite to test both specialized and unspecialized code