### PR TITLE
Turn off the cast profiler by default

### DIFF
--- a/src/configuration.rkt
+++ b/src/configuration.rkt
@@ -55,7 +55,7 @@
 (define hybrid-cast/coercion-runtime? : (Parameterof Boolean)
   (make-parameter #f))
 (define cast-profiler? : (Parameterof Boolean)
-  (make-parameter #t))
+  (make-parameter #f))
 
 
 


### PR DESCRIPTION
It should be off by default.