### PR TITLE
fix some installation-time errors

### DIFF
--- a/benchmark/macro/run.rkt
+++ b/benchmark/macro/run.rkt
@@ -1,5 +1,4 @@
-#!racket
-#lang typed/racket
+#!typed/racket
 
 ;; for each benchmark
 ;; shell script that compiles, and runs benchmark n-times adding

--- a/benchmark/macro/src/info.rkt
+++ b/benchmark/macro/src/info.rkt
@@ -1,0 +1,4 @@
+#lang info
+
+(define compile-omit-paths
+  '("gambit"))

--- a/benchmark/macro/suite/src/info.rkt
+++ b/benchmark/macro/suite/src/info.rkt
@@ -1,0 +1,9 @@
+#lang info
+
+(define compile-omit-paths
+  '("c"
+    "chezscheme"
+    "dyn"
+    "gambit"
+    "partial"
+    "static"))

--- a/benchmark/suite/fn-call/info.rkt
+++ b/benchmark/suite/fn-call/info.rkt
@@ -1,0 +1,4 @@
+#lang info
+
+(define compile-omit-paths
+  '("src/gambit.scm"))

--- a/benchmark/suite/macro/src/info.rkt
+++ b/benchmark/suite/macro/src/info.rkt
@@ -1,0 +1,5 @@
+#lang info
+
+(define compile-omit-paths
+  '("gambit"
+    "chezscheme"))

--- a/tests/ast-interps/data-lang-interp.rkt
+++ b/tests/ast-interps/data-lang-interp.rkt
@@ -11,7 +11,7 @@
 
 (require grift/src/helpers
          grift/src/errors
-	 grift/testing/values
+	 grift/tests/values
 	 grift/src/language
          racket/fixnum)
 

--- a/tests/ast-interps/lambda-lang-interp.rkt
+++ b/tests/ast-interps/lambda-lang-interp.rkt
@@ -11,7 +11,7 @@
 
 (require grift/src/helpers
          grift/src/errors
-	 grift/testing/values
+	 grift/tests/values
 	 grift/src/language
          racket/fixnum)
 

--- a/tests/benchmark.rkt
+++ b/tests/benchmark.rkt
@@ -11,8 +11,8 @@ and prints the timing log to the variable named benchmark-log-file.
 (require racket/port)
 (require grift/src/compile
          grift/src/helpers
-         grift/testing/paths
-         grift/testing/values
+         grift/tests/paths
+         grift/tests/values
          grift/src/errors)
 
 ;; This structure is a list representing the arguments to a call to bench

--- a/tests/suite/core/binding/tests.rkt
+++ b/tests/suite/core/binding/tests.rkt
@@ -2,7 +2,7 @@
 
 (require typed/rackunit
          typed/rackunit/text-ui
-         grift/testing/test-compile)
+         grift/tests/test-compile)
 
 (provide (all-defined-out))
 

--- a/tests/suite/core/control/tests.rkt
+++ b/tests/suite/core/control/tests.rkt
@@ -2,7 +2,7 @@
 
 (require typed/rackunit
          typed/rackunit/text-ui
-         grift/testing/test-compile)
+         grift/tests/test-compile)
 
 (provide (all-defined-out))
 

--- a/tests/suite/core/value/tests.rkt
+++ b/tests/suite/core/value/tests.rkt
@@ -2,7 +2,7 @@
 
 (require typed/rackunit
          typed/rackunit/text-ui
-         grift/testing/test-compile)
+         grift/tests/test-compile)
 
 (provide (all-defined-out))
 

--- a/tests/suite/static/binding/tests.rkt
+++ b/tests/suite/static/binding/tests.rkt
@@ -2,7 +2,7 @@
 
 (require typed/rackunit
          typed/rackunit/text-ui
-         grift/testing/test-compile)
+         grift/tests/test-compile)
 
 (provide (all-defined-out))
 

--- a/tests/suite/static/control/tests.rkt
+++ b/tests/suite/static/control/tests.rkt
@@ -2,7 +2,7 @@
 
 (require typed/rackunit
          typed/rackunit/text-ui
-         grift/testing/test-compile)
+         grift/tests/test-compile)
 
 (provide (all-defined-out))
 

--- a/tests/suite/static/value/tests.rkt
+++ b/tests/suite/static/value/tests.rkt
@@ -2,7 +2,7 @@
 
 (require typed/rackunit
          typed/rackunit/text-ui
-         grift/testing/test-compile)
+         grift/tests/test-compile)
 
 (provide (all-defined-out))
 


### PR DESCRIPTION
When following the installation instructions in `README.md`, I get a number of errors. I've fixed a bunch of the easy ones in this pull request, but there are more, as listed below. (As you probably know, you can run `raco setup grift` to get the full set any time.)

One thing I noticed that seemed worth suggesting: it doesn't seem like grift is on the [pkg server](https://pkgs.racket-lang.org/). If you add it, you'll get the benefit of periodic attempts to build (as racket itself changes) that you can check in on and see how they are doing. Even better, just before each (racket) release, we double check to see if the new version of racket is causing any regressions in packages listed on the pkg server and we look into them before we release.

Also, it may be the case that there is another pkg that you're using, perhaps called `gsi-script`? If so, and if you also put that on the pkg server, then you'll get the benefit of automatic installation and dependency tracking. (You'd have to note the dependency in your `info.rkt` file, but running `raco setup` (with no arguments) will tell you, at the end, if there are any dependencies not explicitly listed.)

```
$  raco setup grift
raco setup: version: 7.0.0.4
raco setup: platform: x86_64-macosx [3m]
raco setup: installation name: development
raco setup: variants: 3m
raco setup: main collects: /Users/robby/git/exp/plt/racket/collects
raco setup: collects paths: 
raco setup:   /Users/robby/Library/Racket/development/collects
raco setup:   /Users/robby/git/exp/plt/racket/collects
raco setup: main pkgs: /Users/robby/git/exp/plt/racket/share/pkgs
raco setup: pkgs paths: 
raco setup:   /Users/robby/git/exp/plt/racket/share/pkgs
raco setup:   /Users/robby/Library/Racket/development/pkgs
raco setup: links files: 
raco setup:   /Users/robby/git/exp/plt/racket/share/links.rktd
raco setup:   /Users/robby/Library/Racket/development/links.rktd
raco setup: main docs: /Users/robby/git/exp/plt/racket/doc
raco setup: --- updating info-domain tables ---
raco setup: --- pre-installing collections ---
raco setup: --- installing foreign libraries ---
raco setup: --- installing shared files ---
raco setup: --- compiling collections ---
raco setup: --- parallel build using 4 jobs ---
raco setup: 3 making: <pkgs>/Grift
raco setup: 3 making: <pkgs>/Grift/benchmark
raco setup: 3 making: <pkgs>/Grift/benchmark/macro
raco setup: 3 making: <pkgs>/Grift/benchmark/macro/src
raco setup: 3 making: <pkgs>/Grift/benchmark/macro/src/c
raco setup: 3 making: <pkgs>/Grift/benchmark/macro/src/c/src
raco setup: 3 making: <pkgs>/Grift/benchmark/macro/src/inputs
raco setup: 3 making: <pkgs>/Grift/benchmark/macro/src/racket
raco setup: 3 making: <pkgs>/Grift/benchmark/macro/src/racket/src
raco setup: 3 making: <pkgs>/Grift/benchmark/macro/src/schml
raco setup: 3 making: <pkgs>/Grift/benchmark/macro/src/schml/dynamic
raco setup: 3 making: <pkgs>/Grift/benchmark/macro/src/schml/dynamic/casts
raco setup: 3 making: <pkgs>/Grift/benchmark/macro/src/schml/dynamic/coercions
raco setup: 3 making: <pkgs>/Grift/benchmark/macro/src/schml/dynamic/src
raco setup: 3 making: <pkgs>/Grift/benchmark/macro/src/schml/out
raco setup: 3 making: <pkgs>/Grift/benchmark/macro/src/schml/partial
raco setup: 3 making: <pkgs>/Grift/benchmark/macro/src/schml/partial/casts
raco setup: 3 making: <pkgs>/Grift/benchmark/macro/src/schml/partial/coercions
raco setup: 3 making: <pkgs>/Grift/benchmark/macro/src/schml/static
raco setup: 3 making: <pkgs>/Grift/benchmark/macro/src/schml/static/casts
raco setup: 3 making: <pkgs>/Grift/benchmark/macro/src/schml/static/coercions
raco setup: 3 making: <pkgs>/Grift/benchmark/macro/src/schml/static/src
raco setup: 3 making: <pkgs>/Grift/benchmark/macro/suite
raco setup: 3 making: <pkgs>/Grift/benchmark/macro/suite/inputs
raco setup: 3 making: <pkgs>/Grift/benchmark/macro/suite/inputs/array
raco setup: 3 making: <pkgs>/Grift/benchmark/macro/suite/inputs/blackscholes
raco setup: 3 making: <pkgs>/Grift/benchmark/macro/suite/inputs/quicksort
raco setup: 3 making: <pkgs>/Grift/benchmark/macro/suite/inputs/tak
raco setup: 3 making: <pkgs>/Grift/benchmark/macro/suite/src
raco setup: 3 making: <pkgs>/Grift/benchmark/macro/suite/src/racket
raco setup: 3 making: <pkgs>/Grift/benchmark/micro
raco setup: 3 making: <pkgs>/Grift/benchmark/micro/dynamic
raco setup: 3 making: <pkgs>/Grift/benchmark/micro/dynamic/src
standard-module-name-resolver: collection not found
  for module path: (submod gsi-script reader)
  collection: "gsi-script"
  in collection directories:
   /Users/robby/Library/Racket/development/collects
   /Users/robby/git/exp/plt/racket/collects
   ... [196 additional linked and package directories]
  compilation context...:
   /Users/robby/git/Grift/benchmark/micro/dynamic/src/Call.scm
  context...:
   show-collection-err
   standard-module-name-resolver
   module-path-index-resolve
   /Users/robby/git/exp/plt/racket/collects/compiler/private/cm-minimal.rkt:315:23
   read-extension44
   read-syntax
   /Users/robby/git/exp/plt/racket/collects/syntax/private/modcode-noctc.rkt:34:2: reader
   /Users/robby/git/exp/plt/racket/collects/syntax/private/modcode-noctc.rkt:257:5: compile-one
   /Users/robby/git/exp/plt/racket/collects/compiler/private/cm-minimal.rkt:273:0: compile-zo*
   /Users/robby/git/exp/plt/racket/collects/compiler/private/cm-minimal.rkt:489:26
   /Users/robby/git/exp/plt/racket/collects/compiler/private/cm-minimal.rkt:481:42
   /Users/robby/git/exp/plt/racket/collects/compiler/private/cm-minimal.rkt:551:0: compile-root
   /Users/robby/git/exp/plt/racket/collects/compiler/private/cm-minimal.rkt:653:4
   /Users/robby/git/exp/plt/racket/collects/setup/../racket/private/more-scheme.rkt:261:28
   [repeats 1 more time]
   /Users/robby/git/exp/plt/racket/collects/setup/parallel-do.rkt:435:20: loop
standard-module-name-resolver: collection not found
  for module path: (submod gsi-script reader)
  collection: "gsi-script"
  in collection directories:
   /Users/robby/Library/Racket/development/collects
   /Users/robby/git/exp/plt/racket/collects
   ... [196 additional linked and package directories]
  compilation context...:
   /Users/robby/git/Grift/benchmark/micro/dynamic/src/CallOverhead.scm
  context...:
   show-collection-err
   standard-module-name-resolver
   module-path-index-resolve
   /Users/robby/git/exp/plt/racket/collects/compiler/private/cm-minimal.rkt:315:23
   read-extension44
   read-syntax
   /Users/robby/git/exp/plt/racket/collects/syntax/private/modcode-noctc.rkt:34:2: reader
   /Users/robby/git/exp/plt/racket/collects/syntax/private/modcode-noctc.rkt:257:5: compile-one
   /Users/robby/git/exp/plt/racket/collects/compiler/private/cm-minimal.rkt:273:0: compile-zo*
   /Users/robby/git/exp/plt/racket/collects/compiler/private/cm-minimal.rkt:489:26
   /Users/robby/git/exp/plt/racket/collects/compiler/private/cm-minimal.rkt:481:42
   /Users/robby/git/exp/plt/racket/collects/compiler/private/cm-minimal.rkt:551:0: compile-root
   /Users/robby/git/exp/plt/racket/collects/compiler/private/cm-minimal.rkt:653:4
   /Users/robby/git/exp/plt/racket/collects/setup/../racket/private/more-scheme.rkt:261:28
   [repeats 1 more time]
   /Users/robby/git/exp/plt/racket/collects/setup/parallel-do.rkt:435:20: loop
standard-module-name-resolver: collection not found
  for module path: (submod gsi-script reader)
  collection: "gsi-script"
  in collection directories:
   /Users/robby/Library/Racket/development/collects
   /Users/robby/git/exp/plt/racket/collects
   ... [196 additional linked and package directories]
  compilation context...:
   /Users/robby/git/Grift/benchmark/micro/dynamic/src/Ref.scm
  context...:
   show-collection-err
   standard-module-name-resolver
   module-path-index-resolve
   /Users/robby/git/exp/plt/racket/collects/compiler/private/cm-minimal.rkt:315:23
   read-extension44
   read-syntax
   /Users/robby/git/exp/plt/racket/collects/syntax/private/modcode-noctc.rkt:34:2: reader
   /Users/robby/git/exp/plt/racket/collects/syntax/private/modcode-noctc.rkt:257:5: compile-one
   /Users/robby/git/exp/plt/racket/collects/compiler/private/cm-minimal.rkt:273:0: compile-zo*
   /Users/robby/git/exp/plt/racket/collects/compiler/private/cm-minimal.rkt:489:26
   /Users/robby/git/exp/plt/racket/collects/compiler/private/cm-minimal.rkt:481:42
   /Users/robby/git/exp/plt/racket/collects/compiler/private/cm-minimal.rkt:551:0: compile-root
   /Users/robby/git/exp/plt/racket/collects/compiler/private/cm-minimal.rkt:653:4
   /Users/robby/git/exp/plt/racket/collects/setup/../racket/private/more-scheme.rkt:261:28
   [repeats 1 more time]
   /Users/robby/git/exp/plt/racket/collects/setup/parallel-do.rkt:435:20: loop
raco setup: 3 making: <pkgs>/Grift/benchmark/micro/partial
standard-module-name-resolver: collection not found
  for module path: (submod gsi-script reader)
  collection: "gsi-script"
  in collection directories:
   /Users/robby/Library/Racket/development/collects
   /Users/robby/git/exp/plt/racket/collects
   ... [196 additional linked and package directories]
  compilation context...:
   /Users/robby/git/Grift/benchmark/micro/dynamic/src/RefOverhead.scm
  context...:
   show-collection-err
   standard-module-name-resolver
   module-path-index-resolve
   /Users/robby/git/exp/plt/racket/collects/compiler/private/cm-minimal.rkt:315:23
   read-extension44
   read-syntax
   /Users/robby/git/exp/plt/racket/collects/syntax/private/modcode-noctc.rkt:34:2: reader
   /Users/robby/git/exp/plt/racket/collects/syntax/private/modcode-noctc.rkt:257:5: compile-one
   /Users/robby/git/exp/plt/racket/collects/compiler/private/cm-minimal.rkt:273:0: compile-zo*
   /Users/robby/git/exp/plt/racket/collects/compiler/private/cm-minimal.rkt:489:26
   /Users/robby/git/exp/plt/racket/collects/compiler/private/cm-minimal.rkt:481:42
   /Users/robby/git/exp/plt/racket/collects/compiler/private/cm-minimal.rkt:551:0: compile-root
   /Users/robby/git/exp/plt/racket/collects/compiler/private/cm-minimal.rkt:653:4
   /Users/robby/git/exp/plt/racket/collects/setup/../racket/private/more-scheme.rkt:261:28
   [repeats 1 more time]
   /Users/robby/git/exp/plt/racket/collects/setup/parallel-do.rkt:435:20: loop
raco setup: 3 making: <pkgs>/Grift/benchmark/micro/static
standard-module-name-resolver: collection not found
  for module path: benchmark
  collection: "benchmark"
  in collection directories:
   /Users/robby/Library/Racket/development/collects
   /Users/robby/git/exp/plt/racket/collects
   ... [196 additional linked and package directories]
  compilation context...:
   /Users/robby/git/Grift/benchmark/micro/dynamic/run.rkt
  context...:
   show-collection-err
   standard-module-name-resolver
   perform-require!78
   for-loop
   finish
   [repeats 4 more times]
   pass-1-and-2-loop
   module-begin-k
   expand-module18
   expand-capturing-lifts
   expand-single
   temp74_0
   compile16
   /Users/robby/git/exp/plt/racket/collects/compiler/private/cm-minimal.rkt:273:0: compile-zo*
   /Users/robby/git/exp/plt/racket/collects/compiler/private/cm-minimal.rkt:489:26
   /Users/robby/git/exp/plt/racket/collects/compiler/private/cm-minimal.rkt:481:42
   ...
<pkgs>/Grift/benchmark/macro/run.rkt:46.0: define: expected more terms starting with the identifier `:' or any term
  at: ()
  within: (define (parse-output))
  in: (define (parse-output))
  compilation context...:
   /Users/robby/git/Grift/benchmark/macro/run.rkt
  location...:
   benchmark/macro/run.rkt:46:0
  context...:
   /Users/robby/git/exp/plt/racket/collects/syntax/parse/private/runtime-report.rkt:730:0: error/report
   /Users/robby/git/exp/plt/racket/collects/syntax/parse/private/runtime-report.rkt:28:0: call-current-failure-handler
   apply-transformer-in-context
   apply-transformer52
   dispatch-transformer41
   loop
   finish
   [repeats 3 more times]
   pass-1-and-2-loop
   module-begin-k
   do-local-expand56
   /Users/robby/git/exp/plt/extra-pkgs/typed-racket/typed-racket-lib/typed-racket/tc-setup.rkt:94:0: tc-module/full
   /Users/robby/git/exp/plt/extra-pkgs/typed-racket/typed-racket-lib/typed-racket/typed-racket.rkt:23:4: module-begin
   apply-transformer-in-context
   apply-transformer52
   dispatch-transformer41
   ...
raco setup: 3 making: <pkgs>/Grift/benchmark/micro/static/compiled_code
standard-module-name-resolver: collection not found
  for module path: benchmark
  collection: "benchmark"
  in collection directories:
   /Users/robby/Library/Racket/development/collects
   /Users/robby/git/exp/plt/racket/collects
   ... [196 additional linked and package directories]
  compilation context...:
   /Users/robby/git/Grift/benchmark/micro/static/run.rkt
  context...:
   show-collection-err
   standard-module-name-resolver
   perform-require!78
   for-loop
   finish
   [repeats 1 more time]
   pass-1-and-2-loop
   module-begin-k
   expand-module18
   expand-capturing-lifts
   expand-single
   temp74_0
   compile16
   /Users/robby/git/exp/plt/racket/collects/compiler/private/cm-minimal.rkt:273:0: compile-zo*
   /Users/robby/git/exp/plt/racket/collects/compiler/private/cm-minimal.rkt:489:26
   /Users/robby/git/exp/plt/racket/collects/compiler/private/cm-minimal.rkt:481:42
   ...
raco setup: 3 making: <pkgs>/Grift/benchmark/suite
raco setup: 3 making: <pkgs>/Grift/benchmark/suite/fn-app
raco setup: 3 making: <pkgs>/Grift/benchmark/suite/fn-app/logs
raco setup: 3 making: <pkgs>/Grift/benchmark/suite/fn-call
raco setup: 3 making: <pkgs>/Grift/benchmark/suite/fn-call/logs
raco setup: 3 making: <pkgs>/Grift/benchmark/suite/fn-call/src
raco setup: 3 making: <pkgs>/Grift/benchmark/suite/fn-cast
raco setup: 3 making: <pkgs>/Grift/benchmark/suite/fn-cast/logs
raco setup: 3 making: <pkgs>/Grift/benchmark/suite/icfp
standard-module-name-resolver: collection not found
  for module path: benchmark
  collection: "benchmark"
  in collection directories:
   /Users/robby/Library/Racket/development/collects
   /Users/robby/git/exp/plt/racket/collects
   ... [196 additional linked and package directories]
  compilation context...:
   /Users/robby/git/Grift/benchmark/micro/static/run_bogus.rkt
  context...:
   show-collection-err
   standard-module-name-resolver
   perform-require!78
   for-loop
   finish
   [repeats 1 more time]
   pass-1-and-2-loop
   module-begin-k
   expand-module18
   expand-capturing-lifts
   expand-single
   temp74_0
   compile16
   /Users/robby/git/exp/plt/racket/collects/compiler/private/cm-minimal.rkt:273:0: compile-zo*
   /Users/robby/git/exp/plt/racket/collects/compiler/private/cm-minimal.rkt:489:26
   /Users/robby/git/exp/plt/racket/collects/compiler/private/cm-minimal.rkt:481:42
   ...
open-input-file: cannot open module file
  module path: /Users/robby/git/Grift/src/casts/casts-to-coercions.rkt
  path: /Users/robby/git/Grift/src/casts/casts-to-coercions.rkt
  system error: no such file or directory; rktio_err=3
  compilation context...:
   /Users/robby/git/Grift/benchmark/micro/code-templates.rkt
  context...:
   maybe-raise-missing-module
   default-load-handler
   standard-module-name-resolver
   perform-require!78
   for-loop
   finish
   [repeats 4 more times]
   pass-1-and-2-loop
   module-begin-k
   expand-module18
   expand-capturing-lifts
   expand-single
   temp74_0
   compile16
   /Users/robby/git/exp/plt/racket/collects/compiler/private/cm-minimal.rkt:273:0: compile-zo*
   /Users/robby/git/exp/plt/racket/collects/compiler/private/cm-minimal.rkt:489:26
   ...
open-input-file: cannot open module file
  module path: /Users/robby/git/Grift/src/casts/casts-to-coercions.rkt
  path: /Users/robby/git/Grift/src/casts/casts-to-coercions.rkt
  system error: no such file or directory; rktio_err=3
  compilation context...:
   /Users/robby/git/Grift/benchmark/micro/code-templates.rkt
   /Users/robby/git/Grift/benchmark/micro/partial/run.rkt
  context...:
   maybe-raise-missing-module
   default-load-handler
   standard-module-name-resolver
   perform-require!78
   for-loop
   finish
   [repeats 4 more times]
   pass-1-and-2-loop
   module-begin-k
   expand-module18
   expand-capturing-lifts
   expand-single
   temp74_0
   compile16
   /Users/robby/git/exp/plt/racket/collects/compiler/private/cm-minimal.rkt:273:0: compile-zo*
   /Users/robby/git/exp/plt/racket/collects/compiler/private/cm-minimal.rkt:489:26
   ...
open-input-file: cannot open module file
  module path: /Users/robby/git/Grift/src/casts/casts-to-coercions.rkt
  path: /Users/robby/git/Grift/src/casts/casts-to-coercions.rkt
  system error: no such file or directory; rktio_err=3
  compilation context...:
   /Users/robby/git/Grift/benchmark/suite/icfp/helpers.rkt
   /Users/robby/git/Grift/benchmark/suite/icfp/code-templates.rkt
  context...:
   maybe-raise-missing-module
   default-load-handler
   standard-module-name-resolver
   perform-require!78
   for-loop
   finish
   [repeats 6 more times]
   pass-1-and-2-loop
   module-begin-k
   expand-module18
   expand-capturing-lifts
   expand-single
   temp74_0
   compile16
   /Users/robby/git/exp/plt/racket/collects/compiler/private/cm-minimal.rkt:273:0: compile-zo*
   /Users/robby/git/exp/plt/racket/collects/compiler/private/cm-minimal.rkt:489:26
   ...
raco setup: 3 making: <pkgs>/Grift/benchmark/suite/lattice
open-input-file: cannot open module file
  module path: /Users/robby/git/Grift/src/casts/casts-to-coercions.rkt
  path: /Users/robby/git/Grift/src/casts/casts-to-coercions.rkt
  system error: no such file or directory; rktio_err=3
  compilation context...:
   /Users/robby/git/Grift/benchmark/suite/icfp/fully-static.rkt
  context...:
   maybe-raise-missing-module
   default-load-handler
   standard-module-name-resolver
   perform-require!78
   for-loop
   finish
   [repeats 6 more times]
   pass-1-and-2-loop
   module-begin-k
   expand-module18
   expand-capturing-lifts
   expand-single
   temp74_0
   compile16
   temp68_1
   standard-module-name-resolver
   ...
raco setup: 3 making: <pkgs>/Grift/benchmark/suite/lattice/misc
raco setup: 3 making: <pkgs>/Grift/benchmark/suite/lattice/src
raco setup: 3 making: <pkgs>/Grift/benchmark/suite/macro
raco setup: 3 making: <pkgs>/Grift/benchmark/suite/macro/inputs
raco setup: 3 making: <pkgs>/Grift/benchmark/suite/macro/inputs/array
raco setup: 3 making: <pkgs>/Grift/benchmark/suite/macro/inputs/blackscholes
raco setup: 3 making: <pkgs>/Grift/benchmark/suite/macro/inputs/cps-even-odd
raco setup: 3 making: <pkgs>/Grift/benchmark/suite/macro/inputs/fft
raco setup: 3 making: <pkgs>/Grift/benchmark/suite/macro/inputs/matmult
raco setup: 3 making: <pkgs>/Grift/benchmark/suite/macro/inputs/n_body
raco setup: 3 making: <pkgs>/Grift/benchmark/suite/macro/inputs/quicksort
raco setup: 3 making: <pkgs>/Grift/benchmark/suite/macro/inputs/ray
raco setup: 3 making: <pkgs>/Grift/benchmark/suite/macro/inputs/tak
raco setup: 3 making: <pkgs>/Grift/benchmark/suite/macro/lib
raco setup: 3 making: <pkgs>/Grift/benchmark/suite/macro/misc
raco setup: 3 making: <pkgs>/Grift/benchmark/suite/macro/notes
raco setup: 3 making: <pkgs>/Grift/benchmark/suite/macro/outputs
raco setup: 3 making: <pkgs>/Grift/benchmark/suite/macro/outputs/chezscheme
raco setup: 3 making: <pkgs>/Grift/benchmark/suite/macro/outputs/chezscheme/array
raco setup: 3 making: <pkgs>/Grift/benchmark/suite/macro/outputs/chezscheme/blackscholes
raco setup: 3 making: <pkgs>/Grift/benchmark/suite/macro/outputs/chezscheme/fft
raco setup: 3 making: <pkgs>/Grift/benchmark/suite/macro/outputs/chezscheme/matmult
raco setup: 3 making: <pkgs>/Grift/benchmark/suite/macro/outputs/chezscheme/n_body
raco setup: 3 making: <pkgs>/Grift/benchmark/suite/macro/outputs/chezscheme/quicksort
raco setup: 3 making: <pkgs>/Grift/benchmark/suite/macro/outputs/chezscheme/ray
raco setup: 3 making: <pkgs>/Grift/benchmark/suite/macro/outputs/chezscheme/tak
raco setup: 3 making: <pkgs>/Grift/benchmark/suite/macro/outputs/dyn
raco setup: 3 making: <pkgs>/Grift/benchmark/suite/macro/outputs/dyn/array
raco setup: 3 making: <pkgs>/Grift/benchmark/suite/macro/outputs/dyn/blackscholes
raco setup: 3 making: <pkgs>/Grift/benchmark/suite/macro/outputs/dyn/fft
raco setup: 3 making: <pkgs>/Grift/benchmark/suite/macro/outputs/dyn/matmult
raco setup: 3 making: <pkgs>/Grift/benchmark/suite/macro/outputs/dyn/n_body
raco setup: 3 making: <pkgs>/Grift/benchmark/suite/macro/outputs/dyn/quicksort
raco setup: 3 making: <pkgs>/Grift/benchmark/suite/macro/outputs/dyn/ray
raco setup: 3 making: <pkgs>/Grift/benchmark/suite/macro/outputs/dyn/tak
raco setup: 3 making: <pkgs>/Grift/benchmark/suite/macro/outputs/gambit
raco setup: 3 making: <pkgs>/Grift/benchmark/suite/macro/outputs/gambit/array
raco setup: 3 making: <pkgs>/Grift/benchmark/suite/macro/outputs/gambit/blackscholes
raco setup: 3 making: <pkgs>/Grift/benchmark/suite/macro/outputs/gambit/fft
raco setup: 3 making: <pkgs>/Grift/benchmark/suite/macro/outputs/gambit/matmult
raco setup: 3 making: <pkgs>/Grift/benchmark/suite/macro/outputs/gambit/n_body
raco setup: 3 making: <pkgs>/Grift/benchmark/suite/macro/outputs/gambit/quicksort
raco setup: 3 making: <pkgs>/Grift/benchmark/suite/macro/outputs/gambit/ray
raco setup: 3 making: <pkgs>/Grift/benchmark/suite/macro/outputs/gambit/tak
raco setup: 3 making: <pkgs>/Grift/benchmark/suite/macro/outputs/ocaml
raco setup: 3 making: <pkgs>/Grift/benchmark/suite/macro/outputs/ocaml/array
raco setup: 3 making: <pkgs>/Grift/benchmark/suite/macro/outputs/ocaml/blackscholes
raco setup: 3 making: <pkgs>/Grift/benchmark/suite/macro/outputs/ocaml/fft
raco setup: 3 making: <pkgs>/Grift/benchmark/suite/macro/outputs/ocaml/matmult
raco setup: 3 making: <pkgs>/Grift/benchmark/suite/macro/outputs/ocaml/n_body
raco setup: 3 making: <pkgs>/Grift/benchmark/suite/macro/outputs/ocaml/quicksort
raco setup: 3 making: <pkgs>/Grift/benchmark/suite/macro/outputs/ocaml/ray
raco setup: 3 making: <pkgs>/Grift/benchmark/suite/macro/outputs/ocaml/tak
raco setup: 3 making: <pkgs>/Grift/benchmark/suite/macro/outputs/racket
raco setup: 3 making: <pkgs>/Grift/benchmark/suite/macro/outputs/racket/array
raco setup: 3 making: <pkgs>/Grift/benchmark/suite/macro/outputs/racket/blackscholes
raco setup: 3 making: <pkgs>/Grift/benchmark/suite/macro/outputs/racket/fft
raco setup: 3 making: <pkgs>/Grift/benchmark/suite/macro/outputs/racket/matmult
raco setup: 3 making: <pkgs>/Grift/benchmark/suite/macro/outputs/racket/n_body
raco setup: 3 making: <pkgs>/Grift/benchmark/suite/macro/outputs/racket/quicksort
raco setup: 3 making: <pkgs>/Grift/benchmark/suite/macro/outputs/racket/ray
raco setup: 3 making: <pkgs>/Grift/benchmark/suite/macro/outputs/racket/tak
raco setup: 3 making: <pkgs>/Grift/benchmark/suite/macro/outputs/static
raco setup: 3 making: <pkgs>/Grift/benchmark/suite/macro/outputs/static/array
raco setup: 3 making: <pkgs>/Grift/benchmark/suite/macro/outputs/static/blackscholes
raco setup: 3 making: <pkgs>/Grift/benchmark/suite/macro/outputs/static/fft
raco setup: 3 making: <pkgs>/Grift/benchmark/suite/macro/outputs/static/matmult
raco setup: 3 making: <pkgs>/Grift/benchmark/suite/macro/outputs/static/n_body
raco setup: 3 making: <pkgs>/Grift/benchmark/suite/macro/outputs/static/quicksort
raco setup: 3 making: <pkgs>/Grift/benchmark/suite/macro/outputs/static/ray
raco setup: 3 making: <pkgs>/Grift/benchmark/suite/macro/outputs/static/tak
raco setup: 3 making: <pkgs>/Grift/benchmark/suite/macro/outputs/typed_racket
raco setup: 3 making: <pkgs>/Grift/benchmark/suite/macro/outputs/typed_racket/array
raco setup: 3 making: <pkgs>/Grift/benchmark/suite/macro/outputs/typed_racket/blackscholes
raco setup: 3 making: <pkgs>/Grift/benchmark/suite/macro/outputs/typed_racket/fft
raco setup: 3 making: <pkgs>/Grift/benchmark/suite/macro/outputs/typed_racket/matmult
raco setup: 3 making: <pkgs>/Grift/benchmark/suite/macro/outputs/typed_racket/n_body
raco setup: 3 making: <pkgs>/Grift/benchmark/suite/macro/outputs/typed_racket/quicksort
raco setup: 3 making: <pkgs>/Grift/benchmark/suite/macro/outputs/typed_racket/ray
raco setup: 3 making: <pkgs>/Grift/benchmark/suite/macro/outputs/typed_racket/tak
raco setup: 3 making: <pkgs>/Grift/benchmark/suite/macro/src
raco setup: 3 making: <pkgs>/Grift/benchmark/suite/macro/src/c
raco setup: 3 making: <pkgs>/Grift/benchmark/suite/macro/src/dyn
raco setup: 3 making: <pkgs>/Grift/benchmark/suite/macro/src/ocaml
raco setup: 3 making: <pkgs>/Grift/benchmark/suite/macro/src/partial
raco setup: 3 making: <pkgs>/Grift/benchmark/suite/macro/src/partial/cps-even-odd
raco setup: 3 making: <pkgs>/Grift/benchmark/suite/macro/src/partial/matmult
raco setup: 3 making: <pkgs>/Grift/benchmark/suite/macro/src/partial/quicksort
raco setup: 3 making: <pkgs>/Grift/benchmark/suite/macro/src/racket
open-input-file: cannot open module file
  module path: /Users/robby/git/Grift/src/casts/casts-to-coercions.rkt
  path: /Users/robby/git/Grift/src/casts/casts-to-coercions.rkt
  system error: no such file or directory; rktio_err=3
  compilation context...:
   /Users/robby/git/Grift/benchmark/suite/icfp/partially-typed-fn-cast.rkt
  context...:
   maybe-raise-missing-module
   default-load-handler
   standard-module-name-resolver
   perform-require!78
   for-loop
   finish
   [repeats 6 more times]
   pass-1-and-2-loop
   module-begin-k
   expand-module18
   expand-capturing-lifts
   expand-single
   temp74_0
   compile16
   temp68_1
   standard-module-name-resolver
   ...
raco setup: 3 making: <pkgs>/Grift/benchmark/suite/macro/src/static
raco setup: 3 making: <pkgs>/Grift/benchmark/suite/macro/src/typed_racket
open-input-file: cannot open module file
  module path: /Users/robby/git/Grift/src/casts/casts-to-coercions.rkt
  path: /Users/robby/git/Grift/src/casts/casts-to-coercions.rkt
  system error: no such file or directory; rktio_err=3
  compilation context...:
   /Users/robby/git/Grift/benchmark/suite/icfp/helpers.rkt
   /Users/robby/git/Grift/benchmark/suite/icfp/timing-loop.rkt
  context...:
   maybe-raise-missing-module
   default-load-handler
   standard-module-name-resolver
   perform-require!78
   for-loop
   finish
   [repeats 6 more times]
   pass-1-and-2-loop
   module-begin-k
   expand-module18
   expand-capturing-lifts
   expand-single
   temp74_0
   compile16
   /Users/robby/git/exp/plt/racket/collects/compiler/private/cm-minimal.rkt:273:0: compile-zo*
   /Users/robby/git/exp/plt/racket/collects/compiler/private/cm-minimal.rkt:489:26
   ...
raco setup: 3 making: <pkgs>/Grift/benchmark/suite/macro/src/typed_racket/internal
raco setup: 3 making: <pkgs>/Grift/benchmark/suite/micro
raco setup: 3 making: <pkgs>/Grift/benchmark/suite/micro/dynamic
raco setup: 3 making: <pkgs>/Grift/benchmark/suite/micro/dynamic/funcalls
raco setup: 3 making: <pkgs>/Grift/benchmark/suite/micro/dynamic/funcalls/src
raco setup: 3 making: <pkgs>/Grift/benchmark/suite/micro/dynamic/refs
load-handler: expected a `module` declaration in #<path:/Users/robby/git/Grift/benchmark/suite/micro/dynamic/funcalls/src/scall.scm>, but found something else
  compilation context...:
   /Users/robby/git/Grift/benchmark/suite/micro/dynamic/funcalls/src/scall.scm
  context...:
   /Users/robby/git/exp/plt/racket/collects/syntax/private/modcode-noctc.rkt:34:2: reader
   /Users/robby/git/exp/plt/racket/collects/syntax/private/modcode-noctc.rkt:257:5: compile-one
   /Users/robby/git/exp/plt/racket/collects/compiler/private/cm-minimal.rkt:273:0: compile-zo*
   /Users/robby/git/exp/plt/racket/collects/compiler/private/cm-minimal.rkt:489:26
   /Users/robby/git/exp/plt/racket/collects/compiler/private/cm-minimal.rkt:481:42
   /Users/robby/git/exp/plt/racket/collects/compiler/private/cm-minimal.rkt:551:0: compile-root
   /Users/robby/git/exp/plt/racket/collects/compiler/private/cm-minimal.rkt:653:4
   /Users/robby/git/exp/plt/racket/collects/setup/../racket/private/more-scheme.rkt:261:28
   [repeats 1 more time]
   /Users/robby/git/exp/plt/racket/collects/setup/parallel-do.rkt:435:20: loop
raco setup: 3 making: <pkgs>/Grift/benchmark/suite/micro/dynamic/refs/src
load-handler: expected a `module` declaration in #<path:/Users/robby/git/Grift/benchmark/suite/micro/dynamic/funcalls/src/soverhead.scm>, but found something else
  compilation context...:
   /Users/robby/git/Grift/benchmark/suite/micro/dynamic/funcalls/src/soverhead.scm
  context...:
   /Users/robby/git/exp/plt/racket/collects/syntax/private/modcode-noctc.rkt:34:2: reader
   /Users/robby/git/exp/plt/racket/collects/syntax/private/modcode-noctc.rkt:257:5: compile-one
   /Users/robby/git/exp/plt/racket/collects/compiler/private/cm-minimal.rkt:273:0: compile-zo*
   /Users/robby/git/exp/plt/racket/collects/compiler/private/cm-minimal.rkt:489:26
   /Users/robby/git/exp/plt/racket/collects/compiler/private/cm-minimal.rkt:481:42
   /Users/robby/git/exp/plt/racket/collects/compiler/private/cm-minimal.rkt:551:0: compile-root
   /Users/robby/git/exp/plt/racket/collects/compiler/private/cm-minimal.rkt:653:4
   /Users/robby/git/exp/plt/racket/collects/setup/../racket/private/more-scheme.rkt:261:28
   [repeats 1 more time]
   /Users/robby/git/exp/plt/racket/collects/setup/parallel-do.rkt:435:20: loop
standard-module-name-resolver: collection not found
  for module path: (submod gsi-script reader)
  collection: "gsi-script"
  in collection directories:
   /Users/robby/Library/Racket/development/collects
   /Users/robby/git/exp/plt/racket/collects
   ... [196 additional linked and package directories]
  compilation context...:
   /Users/robby/git/Grift/benchmark/suite/micro/dynamic/refs/src/Call.scm
  context...:
   show-collection-err
   standard-module-name-resolver
   module-path-index-resolve
   /Users/robby/git/exp/plt/racket/collects/compiler/private/cm-minimal.rkt:315:23
   read-extension44
   read-syntax
   /Users/robby/git/exp/plt/racket/collects/syntax/private/modcode-noctc.rkt:34:2: reader
   /Users/robby/git/exp/plt/racket/collects/syntax/private/modcode-noctc.rkt:257:5: compile-one
   /Users/robby/git/exp/plt/racket/collects/compiler/private/cm-minimal.rkt:273:0: compile-zo*
   /Users/robby/git/exp/plt/racket/collects/compiler/private/cm-minimal.rkt:489:26
   /Users/robby/git/exp/plt/racket/collects/compiler/private/cm-minimal.rkt:481:42
   /Users/robby/git/exp/plt/racket/collects/compiler/private/cm-minimal.rkt:551:0: compile-root
   /Users/robby/git/exp/plt/racket/collects/compiler/private/cm-minimal.rkt:653:4
   /Users/robby/git/exp/plt/racket/collects/setup/../racket/private/more-scheme.rkt:261:28
   [repeats 1 more time]
   /Users/robby/git/exp/plt/racket/collects/setup/parallel-do.rkt:435:20: loop
load-handler: expected a `module` declaration in #<path:/Users/robby/git/Grift/benchmark/suite/micro/dynamic/refs/src/CallOverhead.scm>, but found something else
  compilation context...:
   /Users/robby/git/Grift/benchmark/suite/micro/dynamic/refs/src/CallOverhead.scm
  context...:
   /Users/robby/git/exp/plt/racket/collects/syntax/private/modcode-noctc.rkt:34:2: reader
   /Users/robby/git/exp/plt/racket/collects/syntax/private/modcode-noctc.rkt:257:5: compile-one
   /Users/robby/git/exp/plt/racket/collects/compiler/private/cm-minimal.rkt:273:0: compile-zo*
   /Users/robby/git/exp/plt/racket/collects/compiler/private/cm-minimal.rkt:489:26
   /Users/robby/git/exp/plt/racket/collects/compiler/private/cm-minimal.rkt:481:42
   /Users/robby/git/exp/plt/racket/collects/compiler/private/cm-minimal.rkt:551:0: compile-root
   /Users/robby/git/exp/plt/racket/collects/compiler/private/cm-minimal.rkt:653:4
   /Users/robby/git/exp/plt/racket/collects/setup/../racket/private/more-scheme.rkt:261:28
   [repeats 1 more time]
   /Users/robby/git/exp/plt/racket/collects/setup/parallel-do.rkt:435:20: loop
load-handler: expected a `module` declaration in #<path:/Users/robby/git/Grift/benchmark/suite/micro/dynamic/refs/src/Ref.scm>, but found something else
  compilation context...:
   /Users/robby/git/Grift/benchmark/suite/micro/dynamic/refs/src/Ref.scm
  context...:
   /Users/robby/git/exp/plt/racket/collects/syntax/private/modcode-noctc.rkt:34:2: reader
   /Users/robby/git/exp/plt/racket/collects/syntax/private/modcode-noctc.rkt:257:5: compile-one
   /Users/robby/git/exp/plt/racket/collects/compiler/private/cm-minimal.rkt:273:0: compile-zo*
   /Users/robby/git/exp/plt/racket/collects/compiler/private/cm-minimal.rkt:489:26
   /Users/robby/git/exp/plt/racket/collects/compiler/private/cm-minimal.rkt:481:42
   /Users/robby/git/exp/plt/racket/collects/compiler/private/cm-minimal.rkt:551:0: compile-root
   /Users/robby/git/exp/plt/racket/collects/compiler/private/cm-minimal.rkt:653:4
   /Users/robby/git/exp/plt/racket/collects/setup/../racket/private/more-scheme.rkt:261:28
   [repeats 1 more time]
   /Users/robby/git/exp/plt/racket/collects/setup/parallel-do.rkt:435:20: loop
load-handler: expected a `module` declaration in #<path:/Users/robby/git/Grift/benchmark/suite/micro/dynamic/refs/src/RefOverhead.scm>, but found something else
  compilation context...:
   /Users/robby/git/Grift/benchmark/suite/micro/dynamic/refs/src/RefOverhead.scm
  context...:
   /Users/robby/git/exp/plt/racket/collects/syntax/private/modcode-noctc.rkt:34:2: reader
   /Users/robby/git/exp/plt/racket/collects/syntax/private/modcode-noctc.rkt:257:5: compile-one
   /Users/robby/git/exp/plt/racket/collects/compiler/private/cm-minimal.rkt:273:0: compile-zo*
   /Users/robby/git/exp/plt/racket/collects/compiler/private/cm-minimal.rkt:489:26
   /Users/robby/git/exp/plt/racket/collects/compiler/private/cm-minimal.rkt:481:42
   /Users/robby/git/exp/plt/racket/collects/compiler/private/cm-minimal.rkt:551:0: compile-root
   /Users/robby/git/exp/plt/racket/collects/compiler/private/cm-minimal.rkt:653:4
   /Users/robby/git/exp/plt/racket/collects/setup/../racket/private/more-scheme.rkt:261:28
   [repeats 1 more time]
   /Users/robby/git/exp/plt/racket/collects/setup/parallel-do.rkt:435:20: loop
raco setup: 3 making: <pkgs>/Grift/benchmark/suite/micro/loop
load-handler: expected a `module` declaration in #<path:/Users/robby/git/Grift/benchmark/suite/micro/dynamic/refs/src/sref.scm>, but found something else
  compilation context...:
   /Users/robby/git/Grift/benchmark/suite/micro/dynamic/refs/src/sref.scm
  context...:
   /Users/robby/git/exp/plt/racket/collects/syntax/private/modcode-noctc.rkt:34:2: reader
   /Users/robby/git/exp/plt/racket/collects/syntax/private/modcode-noctc.rkt:257:5: compile-one
   /Users/robby/git/exp/plt/racket/collects/compiler/private/cm-minimal.rkt:273:0: compile-zo*
   /Users/robby/git/exp/plt/racket/collects/compiler/private/cm-minimal.rkt:489:26
   /Users/robby/git/exp/plt/racket/collects/compiler/private/cm-minimal.rkt:481:42
   /Users/robby/git/exp/plt/racket/collects/compiler/private/cm-minimal.rkt:551:0: compile-root
   /Users/robby/git/exp/plt/racket/collects/compiler/private/cm-minimal.rkt:653:4
   /Users/robby/git/exp/plt/racket/collects/setup/../racket/private/more-scheme.rkt:261:28
   [repeats 1 more time]
   /Users/robby/git/exp/plt/racket/collects/setup/parallel-do.rkt:435:20: loop
raco setup: 3 making: <pkgs>/Grift/benchmark/suite/micro/loop/src
raco setup: 3 making: <pkgs>/Grift/benchmark/suite/ref-cast
load-handler: expected a `module` declaration in #<path:/Users/robby/git/Grift/benchmark/suite/micro/loop/src/sloop.scm>, but found something else
  compilation context...:
   /Users/robby/git/Grift/benchmark/suite/micro/loop/src/sloop.scm
  context...:
   /Users/robby/git/exp/plt/racket/collects/syntax/private/modcode-noctc.rkt:34:2: reader
   /Users/robby/git/exp/plt/racket/collects/syntax/private/modcode-noctc.rkt:257:5: compile-one
   /Users/robby/git/exp/plt/racket/collects/compiler/private/cm-minimal.rkt:273:0: compile-zo*
   /Users/robby/git/exp/plt/racket/collects/compiler/private/cm-minimal.rkt:489:26
   /Users/robby/git/exp/plt/racket/collects/compiler/private/cm-minimal.rkt:481:42
   /Users/robby/git/exp/plt/racket/collects/compiler/private/cm-minimal.rkt:551:0: compile-root
   /Users/robby/git/exp/plt/racket/collects/compiler/private/cm-minimal.rkt:653:4
   /Users/robby/git/exp/plt/racket/collects/setup/../racket/private/more-scheme.rkt:261:28
   [repeats 1 more time]
   /Users/robby/git/exp/plt/racket/collects/setup/parallel-do.rkt:435:20: loop
raco setup: 3 making: <pkgs>/Grift/benchmark/suite/ref-cast/misc
raco setup: 3 making: <pkgs>/Grift/benchmark/suite/ref-cast/src
raco setup: 3 making: <pkgs>/Grift/models
standard-module-name-resolver: collection not found
  for module path: benchmark
  collection: "benchmark"
  in collection directories:
   /Users/robby/Library/Racket/development/collects
   /Users/robby/git/exp/plt/racket/collects
   ... [196 additional linked and package directories]
  compilation context...:
   /Users/robby/git/Grift/benchmark/suite/micro/dynamic/refs/run.rkt
  context...:
   show-collection-err
   standard-module-name-resolver
   perform-require!78
   for-loop
   finish
   [repeats 4 more times]
   pass-1-and-2-loop
   module-begin-k
   expand-module18
   expand-capturing-lifts
   expand-single
   temp74_0
   compile16
   /Users/robby/git/exp/plt/racket/collects/compiler/private/cm-minimal.rkt:273:0: compile-zo*
   /Users/robby/git/exp/plt/racket/collects/compiler/private/cm-minimal.rkt:489:26
   /Users/robby/git/exp/plt/racket/collects/compiler/private/cm-minimal.rkt:481:42
   ...
standard-module-name-resolver: collection not found
  for module path: benchmark
  collection: "benchmark"
  in collection directories:
   /Users/robby/Library/Racket/development/collects
   /Users/robby/git/exp/plt/racket/collects
   ... [196 additional linked and package directories]
  compilation context...:
   /Users/robby/git/Grift/benchmark/suite/micro/dynamic/funcalls/run.rkt
  context...:
   show-collection-err
   standard-module-name-resolver
   perform-require!78
   for-loop
   finish
   [repeats 4 more times]
   pass-1-and-2-loop
   module-begin-k
   expand-module18
   expand-capturing-lifts
   expand-single
   temp74_0
   compile16
   /Users/robby/git/exp/plt/racket/collects/compiler/private/cm-minimal.rkt:273:0: compile-zo*
   /Users/robby/git/exp/plt/racket/collects/compiler/private/cm-minimal.rkt:489:26
   /Users/robby/git/exp/plt/racket/collects/compiler/private/cm-minimal.rkt:481:42
   ...
open-input-file: cannot open module file
  module path: /Users/robby/git/Grift/models/helpers.rkt
  path: /Users/robby/git/Grift/models/helpers.rkt
  system error: no such file or directory; rktio_err=3
  compilation context...:
   /Users/robby/git/Grift/models/stlc.rkt
   /Users/robby/git/Grift/models/hyper-coercions.rkt
  context...:
   maybe-raise-missing-module
   default-load-handler
   standard-module-name-resolver
   perform-require!78
   for-loop
   finish
   [repeats 1 more time]
   pass-1-and-2-loop
   module-begin-k
   expand-module18
   expand-capturing-lifts
   expand-single
   temp74_0
   compile16
   /Users/robby/git/exp/plt/racket/collects/compiler/private/cm-minimal.rkt:273:0: compile-zo*
   /Users/robby/git/exp/plt/racket/collects/compiler/private/cm-minimal.rkt:489:26
   ...
raco setup: 3 making: <pkgs>/Grift/src
open-input-file: cannot open module file
  module path: /Users/robby/git/Grift/models/helpers.rkt
  path: /Users/robby/git/Grift/models/helpers.rkt
  system error: no such file or directory; rktio_err=3
  compilation context...:
   /Users/robby/git/Grift/models/stlc.rkt
  context...:
   maybe-raise-missing-module
   default-load-handler
   standard-module-name-resolver
   perform-require!78
   for-loop
   finish
   [repeats 1 more time]
   pass-1-and-2-loop
   module-begin-k
   expand-module18
   expand-capturing-lifts
   expand-single
   temp74_0
   compile16
   /Users/robby/git/exp/plt/racket/collects/compiler/private/cm-minimal.rkt:273:0: compile-zo*
   /Users/robby/git/exp/plt/racket/collects/compiler/private/cm-minimal.rkt:489:26
   ...
src/forms-untyped.rkt:104:3: read-syntax: unexpected `)`
  compilation context...:
   /Users/robby/git/Grift/src/forms-untyped.rkt
   /Users/robby/git/Grift/src/forms-play.rkt
  context...:
   read-undotted
   read-syntax
   /Users/robby/git/exp/plt/racket/collects/syntax/module-reader.rkt:190:25: loop
   /Users/robby/git/exp/plt/racket/collects/syntax/module-reader.rkt:183:2: wrap-internal
   /Users/robby/git/exp/plt/racket/collects/racket/../syntax/module-reader.rkt:65:9: lang:read-syntax
   read-extension44
   read-syntax
   /Users/robby/git/exp/plt/racket/collects/syntax/private/modcode-noctc.rkt:34:2: reader
   /Users/robby/git/exp/plt/racket/collects/syntax/private/modcode-noctc.rkt:257:5: compile-one
   /Users/robby/git/exp/plt/racket/collects/compiler/private/cm-minimal.rkt:273:0: compile-zo*
   /Users/robby/git/exp/plt/racket/collects/compiler/private/cm-minimal.rkt:489:26
   /Users/robby/git/exp/plt/racket/collects/compiler/private/cm-minimal.rkt:481:42
   /Users/robby/git/exp/plt/racket/collects/compiler/private/cm-minimal.rkt:551:0: compile-root
   /Users/robby/git/exp/plt/racket/collects/compiler/private/cm-minimal.rkt:698:4: compilation-manager-load-handler
   standard-module-name-resolver
   perform-require!78
   ...
open-input-file: cannot open module file
  module path: /Users/robby/git/Grift/src/casts/casts-to-coercions.rkt
  path: /Users/robby/git/Grift/src/casts/casts-to-coercions.rkt
  system error: no such file or directory; rktio_err=3
  compilation context...:
   /Users/robby/git/Grift/benchmark/suite/icfp/fn-app-by-casts-for-stop.rkt
  context...:
   maybe-raise-missing-module
   default-load-handler
   standard-module-name-resolver
   perform-require!78
   for-loop
   finish
   [repeats 6 more times]
   pass-1-and-2-loop
   module-begin-k
   expand-module18
   expand-capturing-lifts
   expand-single
   temp74_0
   compile16
   temp68_1
   standard-module-name-resolver
   ...
src/forms-untyped.rkt:104:3: read-syntax: unexpected `)`
  compilation context...:
   /Users/robby/git/Grift/src/forms-untyped.rkt
  context...:
   read-undotted
   read-syntax
   /Users/robby/git/exp/plt/racket/collects/syntax/module-reader.rkt:190:25: loop
   /Users/robby/git/exp/plt/racket/collects/syntax/module-reader.rkt:183:2: wrap-internal
   /Users/robby/git/exp/plt/racket/collects/racket/../syntax/module-reader.rkt:65:9: lang:read-syntax
   read-extension44
   read-syntax
   /Users/robby/git/exp/plt/racket/collects/syntax/private/modcode-noctc.rkt:34:2: reader
   /Users/robby/git/exp/plt/racket/collects/syntax/private/modcode-noctc.rkt:257:5: compile-one
   /Users/robby/git/exp/plt/racket/collects/compiler/private/cm-minimal.rkt:273:0: compile-zo*
   /Users/robby/git/exp/plt/racket/collects/compiler/private/cm-minimal.rkt:489:26
   /Users/robby/git/exp/plt/racket/collects/compiler/private/cm-minimal.rkt:481:42
   /Users/robby/git/exp/plt/racket/collects/compiler/private/cm-minimal.rkt:551:0: compile-root
   /Users/robby/git/exp/plt/racket/collects/compiler/private/cm-minimal.rkt:653:4
   /Users/robby/git/exp/plt/racket/collects/setup/../racket/private/more-scheme.rkt:261:28
   [repeats 1 more time]
raco setup: 3 making: <pkgs>/Grift/src/backend-c
raco setup: 3 making: <pkgs>/Grift/src/backend-c/runtime
raco setup: 3 making: <pkgs>/Grift/src/backend-c/runtime/boehm-gc
raco setup: 3 making: <pkgs>/Grift/src/backend-c/runtime/boehm-gc/Mac_files
raco setup: 3 making: <pkgs>/Grift/src/backend-c/runtime/boehm-gc/cord
raco setup: 3 making: <pkgs>/Grift/src/backend-c/runtime/boehm-gc/extra
raco setup: 3 making: <pkgs>/Grift/src/backend-c/runtime/boehm-gc/include
raco setup: 3 making: <pkgs>/Grift/src/backend-c/runtime/boehm-gc/include/extra
raco setup: 3 making: <pkgs>/Grift/src/backend-c/runtime/boehm-gc/include/private
raco setup: 3 making: <pkgs>/Grift/src/backend-c/runtime/boehm-gc/libatomic_ops
raco setup: 3 making: <pkgs>/Grift/src/backend-c/runtime/boehm-gc/libatomic_ops/pkgconfig
raco setup: 3 making: <pkgs>/Grift/src/backend-c/runtime/boehm-gc/libatomic_ops/src
raco setup: 3 making: <pkgs>/Grift/src/backend-c/runtime/boehm-gc/libatomic_ops/src/atomic_ops
raco setup: 3 making: <pkgs>/Grift/src/backend-c/runtime/boehm-gc/libatomic_ops/src/atomic_ops/sysdeps
raco setup: 3 making: <pkgs>/Grift/src/backend-c/runtime/boehm-gc/libatomic_ops/src/atomic_ops/sysdeps/armcc
raco setup: 3 making: <pkgs>/Grift/src/backend-c/runtime/boehm-gc/libatomic_ops/src/atomic_ops/sysdeps/gcc
raco setup: 3 making: <pkgs>/Grift/src/backend-c/runtime/boehm-gc/libatomic_ops/src/atomic_ops/sysdeps/hpc
raco setup: 3 making: <pkgs>/Grift/src/backend-c/runtime/boehm-gc/libatomic_ops/src/atomic_ops/sysdeps/ibmc
raco setup: 3 making: <pkgs>/Grift/src/backend-c/runtime/boehm-gc/libatomic_ops/src/atomic_ops/sysdeps/icc
raco setup: 3 making: <pkgs>/Grift/src/backend-c/runtime/boehm-gc/libatomic_ops/src/atomic_ops/sysdeps/msftc
raco setup: 3 making: <pkgs>/Grift/src/backend-c/runtime/boehm-gc/libatomic_ops/src/atomic_ops/sysdeps/sunc
raco setup: 3 making: <pkgs>/Grift/src/backend-c/runtime/boehm-gc/libatomic_ops/tests
raco setup: 3 making: <pkgs>/Grift/src/backend-c/runtime/boehm-gc/m4
raco setup: 3 making: <pkgs>/Grift/src/backend-c/runtime/boehm-gc/schml_compiled
raco setup: 3 making: <pkgs>/Grift/src/backend-c/runtime/boehm-gc/schml_compiled/include
raco setup: 3 making: <pkgs>/Grift/src/backend-c/runtime/boehm-gc/schml_compiled/include/gc
raco setup: 3 making: <pkgs>/Grift/src/backend-c/runtime/boehm-gc/schml_compiled/lib
raco setup: 3 making: <pkgs>/Grift/src/backend-c/runtime/boehm-gc/schml_compiled/lib/pkgconfig
raco setup: 3 making: <pkgs>/Grift/src/backend-c/runtime/boehm-gc/schml_compiled/share
raco setup: 3 making: <pkgs>/Grift/src/backend-c/runtime/boehm-gc/schml_compiled/share/gc
raco setup: 3 making: <pkgs>/Grift/src/backend-c/runtime/boehm-gc/tests
raco setup: 3 making: <pkgs>/Grift/src/casts
src/forms-untyped.rkt:104:3: read-syntax: unexpected `)`
  compilation context...:
   /Users/robby/git/Grift/src/forms-untyped.rkt
   /Users/robby/git/Grift/src/forms-typed.rkt
  context...:
   read-undotted
   read-syntax
   /Users/robby/git/exp/plt/racket/collects/syntax/module-reader.rkt:190:25: loop
   /Users/robby/git/exp/plt/racket/collects/syntax/module-reader.rkt:183:2: wrap-internal
   /Users/robby/git/exp/plt/racket/collects/racket/../syntax/module-reader.rkt:65:9: lang:read-syntax
   read-extension44
   read-syntax
   /Users/robby/git/exp/plt/racket/collects/syntax/private/modcode-noctc.rkt:34:2: reader
   /Users/robby/git/exp/plt/racket/collects/syntax/private/modcode-noctc.rkt:257:5: compile-one
   /Users/robby/git/exp/plt/racket/collects/compiler/private/cm-minimal.rkt:273:0: compile-zo*
   /Users/robby/git/exp/plt/racket/collects/compiler/private/cm-minimal.rkt:489:26
   /Users/robby/git/exp/plt/racket/collects/compiler/private/cm-minimal.rkt:481:42
   /Users/robby/git/exp/plt/racket/collects/compiler/private/cm-minimal.rkt:551:0: compile-root
   /Users/robby/git/exp/plt/racket/collects/compiler/private/cm-minimal.rkt:698:4: compilation-manager-load-handler
   standard-module-name-resolver
   syntax-local-module-exports
   ...
raco setup: 3 making: <pkgs>/Grift/src/data
raco setup: 3 making: <pkgs>/Grift/src/grift
raco setup: 3 making: <pkgs>/Grift/src/language
open-input-file: cannot open module file
  module path: /Users/robby/git/Grift/models/base.rkt
  path: /Users/robby/git/Grift/models/base.rkt
  system error: no such file or directory; rktio_err=3
  compilation context...:
   /Users/robby/git/Grift/models/gtlc.rkt
  context...:
   maybe-raise-missing-module
   default-load-handler
   standard-module-name-resolver
   perform-require!78
   for-loop
   finish
   [repeats 2 more times]
   pass-1-and-2-loop
   module-begin-k
   expand-module18
   expand-capturing-lifts
   expand-single
   temp74_0
   compile16
   /Users/robby/git/exp/plt/racket/collects/compiler/private/cm-minimal.rkt:273:0: compile-zo*
   /Users/robby/git/exp/plt/racket/collects/compiler/private/cm-minimal.rkt:489:26
   ...
raco setup: 3 making: <pkgs>/Grift/tests
open-input-file: cannot open module file
  module path: /Users/robby/git/Grift/src/grift/reprovider.rkt
  path: /Users/robby/git/Grift/src/grift/reprovider.rkt
  system error: no such file or directory; rktio_err=3
  compilation context...:
   /Users/robby/git/Grift/src/grift/requirer.rkt
  context...:
   maybe-raise-missing-module
   default-load-handler
   standard-module-name-resolver
   perform-require!78
   for-loop
   finish
   pass-1-and-2-loop
   module-begin-k
   do-local-expand56
   /Users/robby/git/exp/plt/extra-pkgs/typed-racket/typed-racket-lib/typed-racket/tc-setup.rkt:94:0: tc-module/full
   /Users/robby/git/exp/plt/extra-pkgs/typed-racket/typed-racket-lib/typed-racket/typed-racket.rkt:23:4: module-begin
   apply-transformer-in-context
   apply-transformer52
   dispatch-transformer41
   ensure-module-begin36
   expand-module18
   ...
open-input-file: cannot open module file
  module path: /Users/robby/git/Grift/models/base.rkt
  path: /Users/robby/git/Grift/models/base.rkt
  system error: no such file or directory; rktio_err=3
  compilation context...:
   /Users/robby/git/Grift/models/gtlc.rkt
   /Users/robby/git/Grift/models/gtlc-subset-generator.rkt
  context...:
   maybe-raise-missing-module
   default-load-handler
   standard-module-name-resolver
   perform-require!78
   for-loop
   finish
   [repeats 2 more times]
   pass-1-and-2-loop
   module-begin-k
   expand-module18
   expand-capturing-lifts
   expand-single
   temp74_0
   compile16
   /Users/robby/git/exp/plt/racket/collects/compiler/private/cm-minimal.rkt:273:0: compile-zo*
   /Users/robby/git/exp/plt/racket/collects/compiler/private/cm-minimal.rkt:489:26
   ...
src/language/grift.rkt:33:5: Type Checker: wrong number of arguments to polymorphic type
  type: Repeat
  expected: 6
  given: 4
  arguments...: (Uid E E E)
  in: (Repeat Uid E E E)
  compilation context...:
   /Users/robby/git/Grift/src/language/grift.rkt
  location...:
   src/language/grift.rkt:33:5
  context...:
   raise-syntax-error
   f69
   /Users/robby/git/exp/plt/extra-pkgs/typed-racket/typed-racket-lib/typed-racket/private/parse-type.rkt:1083:7: loop
   /Users/robby/git/exp/plt/racket/collects/racket/private/map.rkt:40:19: loop
   [repeats 1 more time]
   /Users/robby/git/exp/plt/racket/collects/racket/private/map.rkt:35:13: map
   fail-handler6187
   ...rivate/parse.rkt:558:26
   /Users/robby/git/exp/plt/extra-pkgs/typed-racket/typed-racket-lib/typed-racket/env/type-alias-helper.rkt:113:4: for-loop
   /Users/robby/git/exp/plt/extra-pkgs/typed-racket/typed-racket-lib/typed-racket/env/type-alias-helper.rkt:101:0: register-all-type-aliases
   /Users/robby/git/exp/plt/extra-pkgs/typed-racket/typed-racket-lib/typed-racket/typecheck/tc-toplevel.rkt:348:0: type-check
   /Users/robby/git/exp/plt/extra-pkgs/typed-racket/typed-racket-lib/typed-racket/typecheck/tc-toplevel.rkt:591:0: tc-module
   /Users/robby/git/exp/plt/extra-pkgs/typed-racket/typed-racket-lib/typed-racket/tc-setup.rkt:94:0: tc-module/full
   /Users/robby/git/exp/plt/extra-pkgs/typed-racket/typed-racket-lib/typed-racket/typed-racket.rkt:23:4: module-begin
   apply-transformer-in-context
   apply-transformer52
   ...
raco setup: 3 making: <pkgs>/Grift/tests/ast-interps
open-input-file: cannot open module file
  module path: grift/src/language
  path: /Users/robby/git/Grift/src/language.rkt
  system error: no such file or directory; rktio_err=3
  compilation context...:
   /Users/robby/git/Grift/tests/program-generator.rkt
  context...:
   maybe-raise-missing-module
   default-load-handler
   standard-module-name-resolver
   perform-require!78
   for-loop
   finish
   [repeats 2 more times]
   pass-1-and-2-loop
   module-begin-k
   do-local-expand56
   /Users/robby/git/exp/plt/extra-pkgs/typed-racket/typed-racket-lib/typed-racket/tc-setup.rkt:94:0: tc-module/full
   /Users/robby/git/exp/plt/extra-pkgs/typed-racket/typed-racket-lib/typed-racket/typed-racket.rkt:23:4: module-begin
   apply-transformer-in-context
   apply-transformer52
   dispatch-transformer41
   ensure-module-begin36
   ...
open-input-file: cannot open module file
  module path: /Users/robby/git/Grift/src/casts/casts-to-coercions.rkt
  path: /Users/robby/git/Grift/src/casts/casts-to-coercions.rkt
  system error: no such file or directory; rktio_err=3
  compilation context...:
   /Users/robby/git/Grift/tests/ast-interps/coercions-ld.rkt
  context...:
   maybe-raise-missing-module
   default-load-handler
   standard-module-name-resolver
   perform-require!78
   for-loop
   finish
   [repeats 15 more times]
   pass-1-and-2-loop
   module-begin-k
   expand-module18
   expand-capturing-lifts
   expand-single
   temp74_0
   compile16
   /Users/robby/git/exp/plt/racket/collects/compiler/private/cm-minimal.rkt:273:0: compile-zo*
   /Users/robby/git/exp/plt/racket/collects/compiler/private/cm-minimal.rkt:489:26
   ...
Unfinished-TODO: tests/ast-interps/cast-lang-interp.rkt:88:10: (TODO ERROR about vilation of the adt invarient)
  compilation context...:
   /Users/robby/git/Grift/tests/ast-interps/cast-lang-interp.rkt
  context...:
   raise-syntax-error
   apply-transformer-in-context
   apply-transformer52
   dispatch-transformer41
   loop
   for-loop
   finish-bodys
   lambda-clause-expander
   loop
   [repeats 39 more times]
   module-begin-k
   do-local-expand56
   /Users/robby/git/exp/plt/extra-pkgs/typed-racket/typed-racket-lib/typed-racket/tc-setup.rkt:94:0: tc-module/full
   /Users/robby/git/exp/plt/extra-pkgs/typed-racket/typed-racket-lib/typed-racket/typed-racket.rkt:23:4: module-begin
   apply-transformer-in-context
   apply-transformer52
   ...
open-input-file: cannot open module file
  module path: grift/src/language
  path: /Users/robby/git/Grift/src/language.rkt
  system error: no such file or directory; rktio_err=3
  compilation context...:
   /Users/robby/git/Grift/tests/ast-interps/data-lang-interp.rkt
  context...:
   maybe-raise-missing-module
   default-load-handler
   standard-module-name-resolver
   perform-require!78
   for-loop
   finish
   [repeats 3 more times]
   pass-1-and-2-loop
   module-begin-k
   do-local-expand56
   /Users/robby/git/exp/plt/extra-pkgs/typed-racket/typed-racket-lib/typed-racket/tc-setup.rkt:94:0: tc-module/full
   /Users/robby/git/exp/plt/extra-pkgs/typed-racket/typed-racket-lib/typed-racket/typed-racket.rkt:23:4: module-begin
   apply-transformer-in-context
   apply-transformer52
   dispatch-transformer41
   ensure-module-begin36
   ...
tests/ast-interps/guarded-references.rkt:21:27: match: insufficient number of fields for structure Ref: expected 3 but got 2; missing fields (Ref-choice)
  at: (_ write)
  in: (Ref _ write)
  compilation context...:
   /Users/robby/git/Grift/tests/ast-interps/guarded-references.rkt
  location...:
   tests/ast-interps/guarded-references.rkt:21:27
  context...:
   raise-syntax-error
   /Users/robby/git/exp/plt/racket/collects/racket/match/parse-helper.rkt:81:0: parse-struct
   [repeats 1 more time]
   /Users/robby/git/exp/plt/racket/collects/racket/match/gen-match.rkt:54:23: for-loop
   /Users/robby/git/exp/plt/racket/collects/racket/match/gen-match.rkt:53:11: mk
   /Users/robby/git/exp/plt/racket/collects/racket/match/gen-match.rkt:44:9: for-loop
   /Users/robby/git/exp/plt/racket/collects/racket/match/../../syntax/parse/private/parse.rkt:1040:13: dots-loop
   /Users/robby/git/exp/plt/racket/collects/racket/match/gen-match.rkt:23:0: go
   apply-transformer-in-context
   apply-transformer52
   dispatch-transformer41
   loop
   for-loop
   finish-bodys
   for-loop
   finish-bodys
   ...
tests/benchmark.rkt:21:37: boole: unbound identifier
  in: boole
  compilation context...:
   /Users/robby/git/Grift/tests/benchmark.rkt
  location...:
   tests/benchmark.rkt:21:37
  context...:
   raise-unbound-syntax-error
   expand-implicit
   for-loop
   [repeats 1 more time]
   loop
   [repeats 7 more times]
   module-begin-k
   do-local-expand56
   /Users/robby/git/exp/plt/extra-pkgs/typed-racket/typed-racket-lib/typed-racket/tc-setup.rkt:94:0: tc-module/full
   /Users/robby/git/exp/plt/extra-pkgs/typed-racket/typed-racket-lib/typed-racket/typed-racket.rkt:23:4: module-begin
   apply-transformer-in-context
   apply-transformer52
   dispatch-transformer41
   ensure-module-begin36
   expand-module18
   expand-capturing-lifts
   ...
raco setup: 3 making: <pkgs>/Grift/tests/suite
tests/ast-interps/new-form-interp.rkt:19:9: module: identifier already required
  at: debug
  in: "../values.rkt"
  compilation context...:
   /Users/robby/git/Grift/tests/ast-interps/new-form-interp.rkt
  location...:
   tests/ast-interps/new-form-interp.rkt:19:9
  context...:
   raise-syntax-error
   for-loop
   check-not-defined95
   for-loop
   [repeats 1 more time]
   perform-require!78
   for-loop
   finish
   [repeats 9 more times]
   pass-1-and-2-loop
   module-begin-k
   expand-module18
   expand-capturing-lifts
   expand-single
   temp74_0
   compile16
   ...
load-handler: expected a `module` declaration in #<path:/Users/robby/git/Grift/tests/suite/p423-valid-tests.ss>, but found something else
  compilation context...:
   /Users/robby/git/Grift/tests/suite/p423-valid-tests.ss
  context...:
   /Users/robby/git/exp/plt/racket/collects/syntax/private/modcode-noctc.rkt:34:2: reader
   /Users/robby/git/exp/plt/racket/collects/syntax/private/modcode-noctc.rkt:257:5: compile-one
   /Users/robby/git/exp/plt/racket/collects/compiler/private/cm-minimal.rkt:273:0: compile-zo*
   /Users/robby/git/exp/plt/racket/collects/compiler/private/cm-minimal.rkt:489:26
   /Users/robby/git/exp/plt/racket/collects/compiler/private/cm-minimal.rkt:481:42
   /Users/robby/git/exp/plt/racket/collects/compiler/private/cm-minimal.rkt:551:0: compile-root
   /Users/robby/git/exp/plt/racket/collects/compiler/private/cm-minimal.rkt:653:4
   /Users/robby/git/exp/plt/racket/collects/setup/../racket/private/more-scheme.rkt:261:28
   [repeats 1 more time]
   /Users/robby/git/exp/plt/racket/collects/setup/parallel-do.rkt:435:20: loop
raco setup: 3 making: <pkgs>/Grift/tests/suite/boxes
raco setup: 3 making: <pkgs>/Grift/tests/suite/core
raco setup: 3 making: <pkgs>/Grift/tests/suite/core/binding
raco setup: 3 making: <pkgs>/Grift/tests/suite/core/control
raco setup: 3 making: <pkgs>/Grift/tests/suite/core/floats
open-input-file: cannot open module file
  module path: /Users/robby/git/Grift/src/language.rkt
  path: /Users/robby/git/Grift/src/language.rkt
  system error: no such file or directory; rktio_err=3
  compilation context...:
   /Users/robby/git/Grift/tests/ast-interps/schml-form-interp.rkt
  context...:
   maybe-raise-missing-module
   default-load-handler
   standard-module-name-resolver
   perform-require!78
   for-loop
   finish
   [repeats 1 more time]
   pass-1-and-2-loop
   module-begin-k
   expand-module18
   expand-capturing-lifts
   expand-single
   temp74_0
   compile16
   /Users/robby/git/exp/plt/racket/collects/compiler/private/cm-minimal.rkt:273:0: compile-zo*
   /Users/robby/git/exp/plt/racket/collects/compiler/private/cm-minimal.rkt:489:26
   ...
raco setup: 3 making: <pkgs>/Grift/tests/suite/core/value
raco setup: 3 making: <pkgs>/Grift/tests/suite/large
open-input-file: cannot open module file
  module path: grift/src/language
  path: /Users/robby/git/Grift/src/language.rkt
  system error: no such file or directory; rktio_err=3
  compilation context...:
   /Users/robby/git/Grift/tests/ast-interps/lambda-lang-interp.rkt
  context...:
   maybe-raise-missing-module
   default-load-handler
   standard-module-name-resolver
   perform-require!78
   for-loop
   finish
   [repeats 3 more times]
   pass-1-and-2-loop
   module-begin-k
   do-local-expand56
   /Users/robby/git/exp/plt/extra-pkgs/typed-racket/typed-racket-lib/typed-racket/tc-setup.rkt:94:0: tc-module/full
   /Users/robby/git/exp/plt/extra-pkgs/typed-racket/typed-racket-lib/typed-racket/typed-racket.rkt:23:4: module-begin
   apply-transformer-in-context
   apply-transformer52
   dispatch-transformer41
   ensure-module-begin36
   ...
raco setup: 3 making: <pkgs>/Grift/tests/suite/monoboxes
raco setup: 3 making: <pkgs>/Grift/tests/suite/monovectors
raco setup: 3 making: <pkgs>/Grift/tests/suite/program
raco setup: 3 making: <pkgs>/Grift/tests/suite/static
raco setup: 3 making: <pkgs>/Grift/tests/suite/static/binding
raco setup: 3 making: <pkgs>/Grift/tests/suite/static/control
tests/debug-compile.rkt:33:9: compiler-config-cast-representation: unbound identifier
  in: compiler-config-cast-representation
  compilation context...:
   /Users/robby/git/Grift/tests/debug-compile.rkt
  location...:
   tests/debug-compile.rkt:33:9
  context...:
   raise-unbound-syntax-error
   expand-implicit
   for-loop
   finish-bodys
   for-loop
   finish-bodys
   lambda-clause-expander
   for-loop
   [repeats 3 more times]
   loop
   [repeats 20 more times]
   module-begin-k
   do-local-expand56
   /Users/robby/git/exp/plt/extra-pkgs/typed-racket/typed-racket-lib/typed-racket/tc-setup.rkt:94:0: tc-module/full
   /Users/robby/git/exp/plt/extra-pkgs/typed-racket/typed-racket-lib/typed-racket/typed-racket.rkt:23:4: module-begin
   apply-transformer-in-context
   ...
raco setup: 3 making: <pkgs>/Grift/tests/suite/static/floats
raco setup: 3 making: <pkgs>/Grift/tests/suite/static/value
raco setup: 3 making: <pkgs>/Grift/tests/suite/tools
make-test-file: undefined;
 cannot reference an identifier before its definition
  in module: 'tests
  internal name: make-test-file
  compilation context...:
   /Users/robby/git/Grift/tests/suite/core/value/tests.rkt
  context...:
   expand+eval-for-syntaxes-binding108
   finish
   [repeats 4 more times]
   pass-1-and-2-loop
   module-begin-k
   do-local-expand56
   /Users/robby/git/exp/plt/extra-pkgs/typed-racket/typed-racket-lib/typed-racket/tc-setup.rkt:94:0: tc-module/full
   /Users/robby/git/exp/plt/extra-pkgs/typed-racket/typed-racket-lib/typed-racket/typed-racket.rkt:23:4: module-begin
   apply-transformer-in-context
   apply-transformer52
   dispatch-transformer41
   ensure-module-begin36
   expand-module18
   expand-capturing-lifts
   expand-single
   temp74_0
   ...
raco setup: 3 making: <pkgs>/Grift/tests/suite/tuples
raco setup: 3 making: <pkgs>/Grift/tests/suite/vectors
<pkgs>/Grift/tests/suite/static/control/tests.rkt:10.2: test-suite: expected expression
  at: #:before
  in: (test-suite #:before (lambda () (display "control tests running ... ")) #:after (lambda () (display "done\n")) (test-file "begin.grift" (int 7)) (test-file "letBegin.grift" (int 5)))
  compilation context...:
   /Users/robby/git/Grift/tests/suite/static/control/tests.rkt
  location...:
   tests/suite/static/control/tests.rkt:11:3
  context...:
   /Users/robby/git/exp/plt/racket/collects/syntax/parse/private/runtime-report.rkt:730:0: error/report
   /Users/robby/git/exp/plt/racket/collects/syntax/parse/private/runtime-report.rkt:28:0: call-current-failure-handler
   apply-transformer-in-context
   apply-transformer52
   dispatch-transformer41
   loop
   [repeats 5 more times]
   module-begin-k
   do-local-expand56
   /Users/robby/git/exp/plt/extra-pkgs/typed-racket/typed-racket-lib/typed-racket/tc-setup.rkt:94:0: tc-module/full
   /Users/robby/git/exp/plt/extra-pkgs/typed-racket/typed-racket-lib/typed-racket/typed-racket.rkt:23:4: module-begin
   apply-transformer-in-context
   apply-transformer52
   dispatch-transformer41
   ensure-module-begin36
   expand-module18
   ...
make-test-file: undefined;
 cannot reference an identifier before its definition
  in module: 'tests
  internal name: make-test-file
  compilation context...:
   /Users/robby/git/Grift/tests/suite/static/value/tests.rkt
  context...:
   expand+eval-for-syntaxes-binding108
   finish
   [repeats 4 more times]
   pass-1-and-2-loop
   module-begin-k
   do-local-expand56
   /Users/robby/git/exp/plt/extra-pkgs/typed-racket/typed-racket-lib/typed-racket/tc-setup.rkt:94:0: tc-module/full
   /Users/robby/git/exp/plt/extra-pkgs/typed-racket/typed-racket-lib/typed-racket/typed-racket.rkt:23:4: module-begin
   apply-transformer-in-context
   apply-transformer52
   dispatch-transformer41
   ensure-module-begin36
   expand-module18
   expand-capturing-lifts
   expand-single
   temp74_0
   ...
<pkgs>/Grift/tests/suite/core/control/tests.rkt:10.2: test-suite: expected expression
  at: #:before
  in: (test-suite #:before (lambda () (display "control tests running ... ")) #:after (lambda () (display "done\n")) (test-file "begin.grift" (int 7)) (test-file "letBegin.grift" (int 5)))
  compilation context...:
   /Users/robby/git/Grift/tests/suite/core/control/tests.rkt
  location...:
   tests/suite/core/control/tests.rkt:11:3
  context...:
   /Users/robby/git/exp/plt/racket/collects/syntax/parse/private/runtime-report.rkt:730:0: error/report
   /Users/robby/git/exp/plt/racket/collects/syntax/parse/private/runtime-report.rkt:28:0: call-current-failure-handler
   apply-transformer-in-context
   apply-transformer52
   dispatch-transformer41
   loop
   [repeats 5 more times]
   module-begin-k
   do-local-expand56
   /Users/robby/git/exp/plt/extra-pkgs/typed-racket/typed-racket-lib/typed-racket/tc-setup.rkt:94:0: tc-module/full
   /Users/robby/git/exp/plt/extra-pkgs/typed-racket/typed-racket-lib/typed-racket/typed-racket.rkt:23:4: module-begin
   apply-transformer-in-context
   apply-transformer52
   dispatch-transformer41
   ensure-module-begin36
   expand-module18
   ...
raco setup: --- creating launchers ---
raco setup: --- installing man pages ---
raco setup: --- building documentation ---
raco setup: --- installing collections ---
raco setup: --- post-installing collections ---
raco setup: --- summary of errors ---
raco setup: error: during making for <pkgs>/Grift/benchmark/micro/dynamic/src
raco setup:   standard-module-name-resolver: collection not found
raco setup:     for module path: (submod gsi-script reader)
raco setup:     collection: "gsi-script"
raco setup:     in collection directories:
raco setup:      /Users/robby/Library/Racket/development/collects
raco setup:      /Users/robby/git/exp/plt/racket/collects
raco setup:      ... [196 additional linked and package directories]
raco setup:     compiling: <pkgs>/Grift/benchmark/micro/dynamic/src/Call.scm
raco setup: error: during making for <pkgs>/Grift/benchmark/micro/dynamic/src
raco setup:   standard-module-name-resolver: collection not found
raco setup:     for module path: (submod gsi-script reader)
raco setup:     collection: "gsi-script"
raco setup:     in collection directories:
raco setup:      /Users/robby/Library/Racket/development/collects
raco setup:      /Users/robby/git/exp/plt/racket/collects
raco setup:      ... [196 additional linked and package directories]
raco setup:     compiling: <pkgs>/Grift/benchmark/micro/dynamic/src/CallOverhead.scm
raco setup: error: during making for <pkgs>/Grift/benchmark/micro/dynamic/src
raco setup:   standard-module-name-resolver: collection not found
raco setup:     for module path: (submod gsi-script reader)
raco setup:     collection: "gsi-script"
raco setup:     in collection directories:
raco setup:      /Users/robby/Library/Racket/development/collects
raco setup:      /Users/robby/git/exp/plt/racket/collects
raco setup:      ... [196 additional linked and package directories]
raco setup:     compiling: <pkgs>/Grift/benchmark/micro/dynamic/src/Ref.scm
raco setup: error: during making for <pkgs>/Grift/benchmark/micro/dynamic/src
raco setup:   standard-module-name-resolver: collection not found
raco setup:     for module path: (submod gsi-script reader)
raco setup:     collection: "gsi-script"
raco setup:     in collection directories:
raco setup:      /Users/robby/Library/Racket/development/collects
raco setup:      /Users/robby/git/exp/plt/racket/collects
raco setup:      ... [196 additional linked and package directories]
raco setup:     compiling: <pkgs>/Grift/benchmark/micro/dynamic/src/RefOverhead.scm
raco setup: error: during making for <pkgs>/Grift/benchmark/micro/dynamic
raco setup:   standard-module-name-resolver: collection not found
raco setup:     for module path: benchmark
raco setup:     collection: "benchmark"
raco setup:     in collection directories:
raco setup:      /Users/robby/Library/Racket/development/collects
raco setup:      /Users/robby/git/exp/plt/racket/collects
raco setup:      ... [196 additional linked and package directories]
raco setup:     compiling: <pkgs>/Grift/benchmark/micro/dynamic/run.rkt
STDERR:
standard-module-name-resolver: collection not found
  for module path: benchmark
  collection: "benchmark"
  in collection directories:
   /Users/robby/Library/Racket/development/collects
   /Users/robby/git/exp/plt/racket/collects
   ... [196 additional linked and package directories]
  context...:
   show-collection-err
   standard-module-name-resolver
   module-path-index-resolve
   /Users/robby/git/exp/plt/racket/collects/syntax/private/modresolve-noctc.rkt:60:0: resolve-module-path10
   /Users/robby/git/exp/plt/racket/collects/setup/parallel-build.rkt:385:11: for-loop
   /Users/robby/git/exp/plt/racket/collects/setup/parallel-build.rkt:371:5: loop
=====
raco setup: error: during making for <pkgs>/Grift/benchmark/macro
raco setup:   <pkgs>/Grift/benchmark/macro/run.rkt:46.0: define: expected more terms starting with the identifier `:' or any term
raco setup:     at: ()
raco setup:     within: (define (parse-output))
raco setup:     in: (define (parse-output))
raco setup:     compiling: <pkgs>/Grift/benchmark/macro/run.rkt
raco setup: error: during making for <pkgs>/Grift/benchmark/micro/static
raco setup:   standard-module-name-resolver: collection not found
raco setup:     for module path: benchmark
raco setup:     collection: "benchmark"
raco setup:     in collection directories:
raco setup:      /Users/robby/Library/Racket/development/collects
raco setup:      /Users/robby/git/exp/plt/racket/collects
raco setup:      ... [196 additional linked and package directories]
raco setup:     compiling: <pkgs>/Grift/benchmark/micro/static/run.rkt
STDERR:
standard-module-name-resolver: collection not found
  for module path: benchmark
  collection: "benchmark"
  in collection directories:
   /Users/robby/Library/Racket/development/collects
   /Users/robby/git/exp/plt/racket/collects
   ... [196 additional linked and package directories]
  context...:
   show-collection-err
   standard-module-name-resolver
   module-path-index-resolve
   /Users/robby/git/exp/plt/racket/collects/syntax/private/modresolve-noctc.rkt:60:0: resolve-module-path10
   /Users/robby/git/exp/plt/racket/collects/setup/parallel-build.rkt:385:11: for-loop
   /Users/robby/git/exp/plt/racket/collects/setup/parallel-build.rkt:371:5: loop
=====
raco setup: error: during making for <pkgs>/Grift/benchmark/micro/static
raco setup:   standard-module-name-resolver: collection not found
raco setup:     for module path: benchmark
raco setup:     collection: "benchmark"
raco setup:     in collection directories:
raco setup:      /Users/robby/Library/Racket/development/collects
raco setup:      /Users/robby/git/exp/plt/racket/collects
raco setup:      ... [196 additional linked and package directories]
raco setup:     compiling: <pkgs>/Grift/benchmark/micro/static/run_bogus.rkt
STDERR:
standard-module-name-resolver: collection not found
  for module path: benchmark
  collection: "benchmark"
  in collection directories:
   /Users/robby/Library/Racket/development/collects
   /Users/robby/git/exp/plt/racket/collects
   ... [196 additional linked and package directories]
  context...:
   show-collection-err
   standard-module-name-resolver
   module-path-index-resolve
   /Users/robby/git/exp/plt/racket/collects/syntax/private/modresolve-noctc.rkt:60:0: resolve-module-path10
   /Users/robby/git/exp/plt/racket/collects/setup/parallel-build.rkt:385:11: for-loop
   /Users/robby/git/exp/plt/racket/collects/setup/parallel-build.rkt:371:5: loop
=====
raco setup: error: during making for <pkgs>/Grift/benchmark/micro
raco setup:   open-input-file: cannot open module file
raco setup:     module path: /Users/robby/git/Grift/src/casts/casts-to-coercions.rkt
raco setup:     path: /Users/robby/git/Grift/src/casts/casts-to-coercions.rkt
raco setup:     system error: no such file or directory; rktio_err=3
raco setup:     compiling: <pkgs>/Grift/benchmark/micro/code-templates.rkt
raco setup: error: during making for <pkgs>/Grift/benchmark/micro/partial
raco setup:   open-input-file: cannot open module file
raco setup:     module path: /Users/robby/git/Grift/src/casts/casts-to-coercions.rkt
raco setup:     path: /Users/robby/git/Grift/src/casts/casts-to-coercions.rkt
raco setup:     system error: no such file or directory; rktio_err=3
raco setup:     compiling: <pkgs>/Grift/benchmark/micro/code-templates.rkt
raco setup: error: during making for <pkgs>/Grift/benchmark/suite/icfp
raco setup:   open-input-file: cannot open module file
raco setup:     module path: /Users/robby/git/Grift/src/casts/casts-to-coercions.rkt
raco setup:     path: /Users/robby/git/Grift/src/casts/casts-to-coercions.rkt
raco setup:     system error: no such file or directory; rktio_err=3
raco setup:     compiling: <pkgs>/Grift/benchmark/suite/icfp/helpers.rkt
raco setup: error: during making for <pkgs>/Grift/benchmark/suite/icfp
raco setup:   open-input-file: cannot open module file
raco setup:     module path: /Users/robby/git/Grift/src/casts/casts-to-coercions.rkt
raco setup:     path: /Users/robby/git/Grift/src/casts/casts-to-coercions.rkt
raco setup:     system error: no such file or directory; rktio_err=3
raco setup:     compiling: <pkgs>/Grift/benchmark/suite/icfp/fully-static.rkt
raco setup: error: during making for <pkgs>/Grift/benchmark/suite/icfp
raco setup:   open-input-file: cannot open module file
raco setup:     module path: /Users/robby/git/Grift/src/casts/casts-to-coercions.rkt
raco setup:     path: /Users/robby/git/Grift/src/casts/casts-to-coercions.rkt
raco setup:     system error: no such file or directory; rktio_err=3
raco setup:     compiling: <pkgs>/Grift/benchmark/suite/icfp/partially-typed-fn-cast.rkt
raco setup: error: during making for <pkgs>/Grift/benchmark/suite/icfp
raco setup:   open-input-file: cannot open module file
raco setup:     module path: /Users/robby/git/Grift/src/casts/casts-to-coercions.rkt
raco setup:     path: /Users/robby/git/Grift/src/casts/casts-to-coercions.rkt
raco setup:     system error: no such file or directory; rktio_err=3
raco setup:     compiling: <pkgs>/Grift/benchmark/suite/icfp/helpers.rkt
raco setup: error: during making for <pkgs>/Grift/benchmark/suite/micro/dynamic/funcalls/src
raco setup:   load-handler: expected a `module` declaration in #<path:/Users/robby/git/Grift/benchmark/suite/micro/dynamic/funcalls/src/scall.scm>, but found something else
raco setup:     compiling: <pkgs>/Grift/benchmark/suite/micro/dynamic/funcalls/src/scall.scm
raco setup: error: during making for <pkgs>/Grift/benchmark/suite/micro/dynamic/funcalls/src
raco setup:   load-handler: expected a `module` declaration in #<path:/Users/robby/git/Grift/benchmark/suite/micro/dynamic/funcalls/src/soverhead.scm>, but found something else
raco setup:     compiling: <pkgs>/Grift/benchmark/suite/micro/dynamic/funcalls/src/soverhead.scm
raco setup: error: during making for <pkgs>/Grift/benchmark/suite/micro/dynamic/refs/src
raco setup:   standard-module-name-resolver: collection not found
raco setup:     for module path: (submod gsi-script reader)
raco setup:     collection: "gsi-script"
raco setup:     in collection directories:
raco setup:      /Users/robby/Library/Racket/development/collects
raco setup:      /Users/robby/git/exp/plt/racket/collects
raco setup:      ... [196 additional linked and package directories]
raco setup:     compiling: <pkgs>/Grift/benchmark/suite/micro/dynamic/refs/src/Call.scm
raco setup: error: during making for <pkgs>/Grift/benchmark/suite/micro/dynamic/refs/src
raco setup:   load-handler: expected a `module` declaration in #<path:/Users/robby/git/Grift/benchmark/suite/micro/dynamic/refs/src/CallOverhead.scm>, but found something else
raco setup:     compiling: <pkgs>/Grift/benchmark/suite/micro/dynamic/refs/src/CallOverhead.scm
raco setup: error: during making for <pkgs>/Grift/benchmark/suite/micro/dynamic/refs/src
raco setup:   load-handler: expected a `module` declaration in #<path:/Users/robby/git/Grift/benchmark/suite/micro/dynamic/refs/src/Ref.scm>, but found something else
raco setup:     compiling: <pkgs>/Grift/benchmark/suite/micro/dynamic/refs/src/Ref.scm
raco setup: error: during making for <pkgs>/Grift/benchmark/suite/micro/dynamic/refs/src
raco setup:   load-handler: expected a `module` declaration in #<path:/Users/robby/git/Grift/benchmark/suite/micro/dynamic/refs/src/RefOverhead.scm>, but found something else
raco setup:     compiling: <pkgs>/Grift/benchmark/suite/micro/dynamic/refs/src/RefOverhead.scm
raco setup: error: during making for <pkgs>/Grift/benchmark/suite/micro/dynamic/refs/src
raco setup:   load-handler: expected a `module` declaration in #<path:/Users/robby/git/Grift/benchmark/suite/micro/dynamic/refs/src/sref.scm>, but found something else
raco setup:     compiling: <pkgs>/Grift/benchmark/suite/micro/dynamic/refs/src/sref.scm
raco setup: error: during making for <pkgs>/Grift/benchmark/suite/micro/loop/src
raco setup:   load-handler: expected a `module` declaration in #<path:/Users/robby/git/Grift/benchmark/suite/micro/loop/src/sloop.scm>, but found something else
raco setup:     compiling: <pkgs>/Grift/benchmark/suite/micro/loop/src/sloop.scm
raco setup: error: during making for <pkgs>/Grift/benchmark/suite/micro/dynamic/refs
raco setup:   standard-module-name-resolver: collection not found
raco setup:     for module path: benchmark
raco setup:     collection: "benchmark"
raco setup:     in collection directories:
raco setup:      /Users/robby/Library/Racket/development/collects
raco setup:      /Users/robby/git/exp/plt/racket/collects
raco setup:      ... [196 additional linked and package directories]
raco setup:     compiling: <pkgs>/Grift/benchmark/suite/micro/dynamic/refs/run.rkt
STDERR:
standard-module-name-resolver: collection not found
  for module path: benchmark
  collection: "benchmark"
  in collection directories:
   /Users/robby/Library/Racket/development/collects
   /Users/robby/git/exp/plt/racket/collects
   ... [196 additional linked and package directories]
  context...:
   show-collection-err
   standard-module-name-resolver
   module-path-index-resolve
   /Users/robby/git/exp/plt/racket/collects/syntax/private/modresolve-noctc.rkt:60:0: resolve-module-path10
   /Users/robby/git/exp/plt/racket/collects/setup/parallel-build.rkt:385:11: for-loop
   /Users/robby/git/exp/plt/racket/collects/setup/parallel-build.rkt:371:5: loop
=====
raco setup: error: during making for <pkgs>/Grift/benchmark/suite/micro/dynamic/funcalls
raco setup:   standard-module-name-resolver: collection not found
raco setup:     for module path: benchmark
raco setup:     collection: "benchmark"
raco setup:     in collection directories:
raco setup:      /Users/robby/Library/Racket/development/collects
raco setup:      /Users/robby/git/exp/plt/racket/collects
raco setup:      ... [196 additional linked and package directories]
raco setup:     compiling: <pkgs>/Grift/benchmark/suite/micro/dynamic/funcalls/run.rkt
STDERR:
standard-module-name-resolver: collection not found
  for module path: benchmark
  collection: "benchmark"
  in collection directories:
   /Users/robby/Library/Racket/development/collects
   /Users/robby/git/exp/plt/racket/collects
   ... [196 additional linked and package directories]
  context...:
   show-collection-err
   standard-module-name-resolver
   module-path-index-resolve
   /Users/robby/git/exp/plt/racket/collects/syntax/private/modresolve-noctc.rkt:60:0: resolve-module-path10
   /Users/robby/git/exp/plt/racket/collects/setup/parallel-build.rkt:385:11: for-loop
   /Users/robby/git/exp/plt/racket/collects/setup/parallel-build.rkt:371:5: loop
=====
raco setup: error: during making for <pkgs>/Grift/models
raco setup:   open-input-file: cannot open module file
raco setup:     module path: /Users/robby/git/Grift/models/helpers.rkt
raco setup:     path: /Users/robby/git/Grift/models/helpers.rkt
raco setup:     system error: no such file or directory; rktio_err=3
raco setup:     compiling: <pkgs>/Grift/models/stlc.rkt
raco setup: error: during making for <pkgs>/Grift/models
raco setup:   open-input-file: cannot open module file
raco setup:     module path: /Users/robby/git/Grift/models/helpers.rkt
raco setup:     path: /Users/robby/git/Grift/models/helpers.rkt
raco setup:     system error: no such file or directory; rktio_err=3
raco setup:     compiling: <pkgs>/Grift/models/stlc.rkt
raco setup: error: during making for <pkgs>/Grift/src
raco setup:   src/forms-untyped.rkt:104:3: read-syntax: unexpected `)`
raco setup:     compiling: <pkgs>/Grift/src/forms-untyped.rkt
raco setup: error: during making for <pkgs>/Grift/benchmark/suite/icfp
raco setup:   open-input-file: cannot open module file
raco setup:     module path: /Users/robby/git/Grift/src/casts/casts-to-coercions.rkt
raco setup:     path: /Users/robby/git/Grift/src/casts/casts-to-coercions.rkt
raco setup:     system error: no such file or directory; rktio_err=3
raco setup:     compiling: <pkgs>/Grift/benchmark/suite/icfp/fn-app-by-casts-for-stop.rkt
raco setup: error: during making for <pkgs>/Grift/src
raco setup:   src/forms-untyped.rkt:104:3: read-syntax: unexpected `)`
raco setup:     compiling: <pkgs>/Grift/src/forms-untyped.rkt
raco setup: error: during making for <pkgs>/Grift/src
raco setup:   src/forms-untyped.rkt:104:3: read-syntax: unexpected `)`
raco setup:     compiling: <pkgs>/Grift/src/forms-untyped.rkt
raco setup: error: during making for <pkgs>/Grift/models
raco setup:   open-input-file: cannot open module file
raco setup:     module path: /Users/robby/git/Grift/models/base.rkt
raco setup:     path: /Users/robby/git/Grift/models/base.rkt
raco setup:     system error: no such file or directory; rktio_err=3
raco setup:     compiling: <pkgs>/Grift/models/gtlc.rkt
raco setup: error: during making for <pkgs>/Grift/src/grift
raco setup:   open-input-file: cannot open module file
raco setup:     module path: /Users/robby/git/Grift/src/grift/reprovider.rkt
raco setup:     path: /Users/robby/git/Grift/src/grift/reprovider.rkt
raco setup:     system error: no such file or directory; rktio_err=3
raco setup:     compiling: <pkgs>/Grift/src/grift/requirer.rkt
raco setup: error: during making for <pkgs>/Grift/models
raco setup:   open-input-file: cannot open module file
raco setup:     module path: /Users/robby/git/Grift/models/base.rkt
raco setup:     path: /Users/robby/git/Grift/models/base.rkt
raco setup:     system error: no such file or directory; rktio_err=3
raco setup:     compiling: <pkgs>/Grift/models/gtlc.rkt
raco setup: error: during making for <pkgs>/Grift/src/language
raco setup:   src/language/grift.rkt:33:5: Type Checker: wrong number of arguments to polymorphic type
raco setup:     type: Repeat
raco setup:     expected: 6
raco setup:     given: 4
raco setup:     arguments...: (Uid E E E)
raco setup:     in: (Repeat Uid E E E)
raco setup:     compiling: <pkgs>/Grift/src/language/grift.rkt
raco setup: error: during making for <pkgs>/Grift/tests
raco setup:   open-input-file: cannot open module file
raco setup:     module path: grift/src/language
raco setup:     path: /Users/robby/git/Grift/src/language.rkt
raco setup:     system error: no such file or directory; rktio_err=3
raco setup:     compiling: <pkgs>/Grift/tests/program-generator.rkt
raco setup: error: during making for <pkgs>/Grift/tests/ast-interps
raco setup:   open-input-file: cannot open module file
raco setup:     module path: /Users/robby/git/Grift/src/casts/casts-to-coercions.rkt
raco setup:     path: /Users/robby/git/Grift/src/casts/casts-to-coercions.rkt
raco setup:     system error: no such file or directory; rktio_err=3
raco setup:     compiling: <pkgs>/Grift/tests/ast-interps/coercions-ld.rkt
raco setup: error: during making for <pkgs>/Grift/tests/ast-interps
raco setup:   Unfinished-TODO: tests/ast-interps/cast-lang-interp.rkt:88:10: (TODO ERROR about vilation of the adt invarient)
raco setup:     compiling: <pkgs>/Grift/tests/ast-interps/cast-lang-interp.rkt
raco setup: error: during making for <pkgs>/Grift/tests/ast-interps
raco setup:   open-input-file: cannot open module file
raco setup:     module path: grift/src/language
raco setup:     path: /Users/robby/git/Grift/src/language.rkt
raco setup:     system error: no such file or directory; rktio_err=3
raco setup:     compiling: <pkgs>/Grift/tests/ast-interps/data-lang-interp.rkt
raco setup: error: during making for <pkgs>/Grift/tests/ast-interps
raco setup:   tests/ast-interps/guarded-references.rkt:21:27: match: insufficient number of fields for structure Ref: expected 3 but got 2; missing fields (Ref-choice)
raco setup:     at: (_ write)
raco setup:     in: (Ref _ write)
raco setup:     compiling: <pkgs>/Grift/tests/ast-interps/guarded-references.rkt
raco setup: error: during making for <pkgs>/Grift/tests
raco setup:   tests/benchmark.rkt:21:37: boole: unbound identifier
raco setup:     in: boole
raco setup:     compiling: <pkgs>/Grift/tests/benchmark.rkt
raco setup: error: during making for <pkgs>/Grift/tests/ast-interps
raco setup:   tests/ast-interps/new-form-interp.rkt:19:9: module: identifier already required
raco setup:     at: debug
raco setup:     in: "../values.rkt"
raco setup:     compiling: <pkgs>/Grift/tests/ast-interps/new-form-interp.rkt
raco setup: error: during making for <pkgs>/Grift/tests/suite
raco setup:   load-handler: expected a `module` declaration in #<path:/Users/robby/git/Grift/tests/suite/p423-valid-tests.ss>, but found something else
raco setup:     compiling: <pkgs>/Grift/tests/suite/p423-valid-tests.ss
raco setup: error: during making for <pkgs>/Grift/tests/ast-interps
raco setup:   open-input-file: cannot open module file
raco setup:     module path: /Users/robby/git/Grift/src/language.rkt
raco setup:     path: /Users/robby/git/Grift/src/language.rkt
raco setup:     system error: no such file or directory; rktio_err=3
raco setup:     compiling: <pkgs>/Grift/tests/ast-interps/schml-form-interp.rkt
raco setup: error: during making for <pkgs>/Grift/tests/ast-interps
raco setup:   open-input-file: cannot open module file
raco setup:     module path: grift/src/language
raco setup:     path: /Users/robby/git/Grift/src/language.rkt
raco setup:     system error: no such file or directory; rktio_err=3
raco setup:     compiling: <pkgs>/Grift/tests/ast-interps/lambda-lang-interp.rkt
raco setup: error: during making for <pkgs>/Grift/tests
raco setup:   tests/debug-compile.rkt:33:9: compiler-config-cast-representation: unbound identifier
raco setup:     in: compiler-config-cast-representation
raco setup:     compiling: <pkgs>/Grift/tests/debug-compile.rkt
raco setup: error: during making for <pkgs>/Grift/tests/suite/core/value
raco setup:   make-test-file: undefined;
raco setup:    cannot reference an identifier before its definition
raco setup:     in module: 'tests
raco setup:     internal name: make-test-file
raco setup:     compiling: <pkgs>/Grift/tests/suite/core/value/tests.rkt
raco setup: error: during making for <pkgs>/Grift/tests/suite/static/control
raco setup:   <pkgs>/Grift/tests/suite/static/control/tests.rkt:10.2: test-suite: expected expression
raco setup:     at: #:before
raco setup:     in: (test-suite #:before (lambda () (display "control tests running ... ")) #:after (lambda () (display "done\n")) (test-file "begin.grift" (int 7)) (test-file "letBegin.grift" (int 5)))
raco setup:     compiling: <pkgs>/Grift/tests/suite/static/control/tests.rkt
raco setup: error: during making for <pkgs>/Grift/tests/suite/static/value
raco setup:   make-test-file: undefined;
raco setup:    cannot reference an identifier before its definition
raco setup:     in module: 'tests
raco setup:     internal name: make-test-file
raco setup:     compiling: <pkgs>/Grift/tests/suite/static/value/tests.rkt
raco setup: error: during making for <pkgs>/Grift/tests/suite/core/control
raco setup:   <pkgs>/Grift/tests/suite/core/control/tests.rkt:10.2: test-suite: expected expression
raco setup:     at: #:before
raco setup:     in: (test-suite #:before (lambda () (display "control tests running ... ")) #:after (lambda () (display "done\n")) (test-file "begin.grift" (int 7)) (test-file "letBegin.grift" (int 5)))
raco setup:     compiling: <pkgs>/Grift/tests/suite/core/control/tests.rkt
```
