### PR TITLE
Update sieve.grift

### DIFF
--- a/tests/suite/program/sieve.grift
+++ b/tests/suite/program/sieve.grift
@@ -62,7 +62,7 @@
 ;; Compute the 10,000th prime number
 (define N-1 : Int 9999)
 
-(define (main) : ()
+(define (main) : Unit
   (begin
     #;(display "The ")
     #;(print-int (+ N-1 1))


### PR DESCRIPTION
(main) was typed as (). 
I change its type to Unit because 
* () is not a type and
* () should not be a type (name conflict with the inhabitor of Unit).