### PR TITLE
LLVM Backend

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_install:
 
 install:
 - # cat /proc/meminfo
-- raco pkg install
+- make install
 
 script:
 - make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,18 @@
-sudo: false
+sudo: true
 language: c
 services:
 - xvfb
-env:
-- PATH=~/racket/bin:$PATH
 
 before_install:
+# Install racket
 - "/sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1280x1024x16"
 - curl -L -o installer.sh http://www.cs.utah.edu/plt/snapshots/current/installers/racket-current-x86_64-linux-precise.sh
 - sh installer.sh --in-place --dest ~/racket/
 - export PATH=~/racket/bin:$PATH
+# Install LLVM
+- sudo bash -c "$(wget -O - https://apt.llvm.org/llvm.sh)"
+- sudo apt-get install libllvm9 llvm-9 llvm-9-dev llvm-9-runtime
+- export LLVM_CONFIG=llvm-config-9
 
 install:
 - # cat /proc/meminfo

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,15 @@ all:
 	raco make -v -j 4 main.rkt
 	cd src/backend-c/runtime/; make
 
+install:
+	raco pkg install --batch --auto --fail-fast --name grift
+
+remove:
+	raco pkg remove --batch --auto grift
+
+update:
+	raco pkg update --batch --auto grift
+
 timed:
 	time raco make main.rkt
 

--- a/info.rkt
+++ b/info.rkt
@@ -3,12 +3,9 @@
 (define version "0.1")
 (define deps
   '(;; Since sham isn't on the package server yet we use a direct link to github
-    "https://github.com/rjnw/sham.git/?path=sham#master"
-    "https://github.com/rjnw/sham.git/?path=sham-llvm#master"
-    "https://github.com/rjnw/sham.git/?path=sham-lib#master"
-    "https://github.com/rjnw/scf.git/?path=scf-lib#master"
-    "https://github.com/rjnw/scf.git/?path=scf-doc#master"
-    "https://github.com/rjnw/scf.git/?path=scf#master"))
+    "https://github.com/rjnw/sham.git/?path=sham-llvm#3dd8cacb82bb4c77b447f76d984fee4f2aae9f0a"
+    "https://github.com/rjnw/sham.git/?path=sham-lib#3dd8cacb82bb4c77b447f76d984fee4f2aae9f0a"
+    "https://github.com/rjnw/scf.git/?path=scf-lib#a9405041f636ac7c4368b736d10f3f8a858eed74"))
 (define racket-launcher-names '("grift" "grift-bench" "grift-configs"))
 (define racket-launcher-libraries '("main.rkt" "benchmark/bench.rkt" "benchmark/configs.rkt"))
 (define post-install-collection "src/backend-c/runtime/make.rkt")

--- a/info.rkt
+++ b/info.rkt
@@ -1,10 +1,19 @@
 #lang info
 (define collection "grift")
 (define version "0.1")
+(define deps
+  '(;; Since sham isn't on the package server yet we use a direct link to github
+    "https://github.com/rjnw/sham.git/?path=sham#master"
+    "https://github.com/rjnw/sham.git/?path=sham-llvm#master"
+    "https://github.com/rjnw/sham.git/?path=sham-lib#master"
+    "https://github.com/rjnw/scf.git/?path=scf-lib#master"
+    "https://github.com/rjnw/scf.git/?path=scf-doc#master"
+    "https://github.com/rjnw/scf.git/?path=scf#master"))
 (define racket-launcher-names '("grift" "grift-bench" "grift-configs"))
 (define racket-launcher-libraries '("main.rkt" "benchmark/bench.rkt" "benchmark/configs.rkt"))
 (define post-install-collection "src/backend-c/runtime/make.rkt")
-(define compile-omit-files '("src/backend-c/runtime/make.rkt"))
+(define compile-omit-files
+  '("src/backend-c/runtime"))
 (define clean
   '("src/backend-c/runtime/boehm-gc-install"
     "src/backend-c/runtime/cast-profiler.o"

--- a/tests/one-off/sham-install.rkt
+++ b/tests/one-off/sham-install.rkt
@@ -1,0 +1,59 @@
+#lang racket
+
+(module+ test
+  (require
+   racket/runtime-path
+   rackunit
+   ffi/unsafe
+   sham/ast
+   sham/ir
+   sham/env
+   sham/llvm/ffi/all
+   sham/llvm/llvm-config)
+
+  (llvm-initialize-all)
+  (define context (LLVMContextCreate))
+
+  (define module
+    (env-get-llvm-module
+     (build-llvm-module
+      (dmodule
+       (hash)
+       'module
+       (list
+        (function^
+         'main () i64
+         (return (ui64 42))))))))
+
+  (define-runtime-path basename "./test42")
+  (define bc-path (path-add-extension basename ".bc"))
+  (define bin-path (llvm-config "--bindir"))
+  (define asm-path (path-add-extension basename ".s"))
+
+  (check-equal?
+   0
+   (LLVMWriteBitcodeToFile module (path->string bc-path)))
+
+  (check-true
+   (system*
+    (build-path bin-path "llc")
+    "-O3"
+    "--relocation-model=pic"
+    bc-path))
+
+  (check-true
+   (system*
+    (build-path bin-path "clang")
+    asm-path
+    "-o"
+    basename))
+
+  (check-equal?
+   42
+   (system*/exit-code basename))
+
+  (delete-file basename)
+  (delete-file bc-path)
+  (delete-file asm-path)
+  (LLVMDisposeModule module)
+  (LLVMContextDispose context))

--- a/tests/one-off/sham-install.rkt
+++ b/tests/one-off/sham-install.rkt
@@ -1,5 +1,10 @@
 #lang racket
-
+;; The intention of the test is to ensure that sham is installed and
+;; that the llvm portion is working. Does our install script
+;; successfully install sham and if the llvm is present can we
+;; generate code. Sham is build around a JIT system which I don't care
+;; about working correctly, and in fact doesn't work on my laptop. The
+;; sham test suite would check the functionality of the JIT.
 (module+ test
   (require
    racket/runtime-path


### PR DESCRIPTION
This pull request starts a branch that will be the development branch of a backend based on the LLVM. The LLVM backend should eventually support tail call optimization. The minimal changes made by this pull request specifically setup the installation of sham a racket library that already has llvm bindings. Sham has JIT functionality that we are not relying on at this time, so the minimal unit test actually bypasses much of sham and directly generates LLVM IR instead of running shams unit tests.