### PR TITLE
Coercion-passing style translation

### DIFF
--- a/main.rkt
+++ b/main.rkt
@@ -185,6 +185,9 @@
    #:once-any
    ["--Boehm" "Use Boehm Conservative Collector" (garbage-collector 'Boehm)]
    ["--No-GC" "Do not Collect Garbage"           (garbage-collector 'None)]
+   #:once-any
+   ["--crcps" "Enable coercion-passing style translation" (enable-crcps? #t)]
+   ["--no-crcps" "Disable coercion-passing style translation" (enable-crcps? #f)]
    #:args args
    (match args
      [(list)

--- a/main.rkt
+++ b/main.rkt
@@ -186,8 +186,10 @@
    ["--Boehm" "Use Boehm Conservative Collector" (garbage-collector 'Boehm)]
    ["--No-GC" "Do not Collect Garbage"           (garbage-collector 'None)]
    #:once-any
-   ["--crcps" "Enable coercion-passing style translation" (enable-crcps? #t)]
-   ["--no-crcps" "Disable coercion-passing style translation" (enable-crcps? #f)]
+   ["--crcps" "Enable coercion-passing style translation"
+    (enable-tail-coercion-composition? #t)]
+   ["--no-crcps" "Disable coercion-passing style translation"
+    (enable-tail-coercion-composition? #f)]
    #:args args
    (match args
      [(list)

--- a/src/casts/coercion-passing.rkt
+++ b/src/casts/coercion-passing.rkt
@@ -19,13 +19,11 @@
                                 #:compose-coercions-uid compose-coercions-uid)
 
   ;; cf. interpret-casts/coercions
-  (define (apply-coercion [v : CoC3-Expr] [c : CoC3-Expr]) : CoC3-Expr
-    ;; TODO: We're not quite sure what these are:
-    ;; mono-address, base-address, index
-    (let ([mono-address ZERO-EXPR]
-          [base-address ZERO-EXPR]
-          [index ZERO-EXPR])
-      (apply-code apply-coercion-uid v c mono-address base-address index)))
+  (define (apply-coercion [v : CoC3-Expr]
+                          [c : CoC3-Expr]
+                          [top-level? : CoC3-Expr (Quote #f)])
+    : CoC3-Expr
+    (apply-code apply-coercion-uid v c top-level?))
 
   ;; coercion composition
   ;; cf. make-compose-coercions in interpret-casts/coercions

--- a/src/casts/coercion-passing.rkt
+++ b/src/casts/coercion-passing.rkt
@@ -251,6 +251,28 @@
         (Unguarded-Vect-length (trans-exp v ID-EXPR))
         cont)]
 
+      ;; monovector:
+      [(Mvector e1 e2 ty)
+       (apply-coercion-opt
+        (Mvector (trans-exp e1 ID-EXPR) (trans-exp e2 ID-EXPR) ty)
+        cont)]
+      [(Mvector-val-ref e1 e2 guarded?)
+       (apply-coercion-opt
+        (Mvector-val-ref (trans-exp e1 ID-EXPR) (trans-exp e2 ID-EXPR) guarded?)
+        cont)]
+      [(Mvector-rtti-ref e)
+       (apply-coercion-opt
+        (Mvector-rtti-ref (trans-exp e ID-EXPR))
+        cont)]
+      [(Mvector-val-set! e1 e2 e3 guarded?)
+       (apply-coercion-opt
+        (Mvector-val-set! (trans-exp e1 ID-EXPR) (trans-exp e2 ID-EXPR) (trans-exp e3 ID-EXPR) guarded?)
+        cont)]
+      [(Mvector-length e)
+       (apply-coercion-opt
+        (Mvector-length (trans-exp e ID-EXPR))
+        cont)]
+
       ;; proxied reference coercions:
       [(Ref-Coercion-Read e)
        (apply-coercion-opt

--- a/src/casts/coercion-passing.rkt
+++ b/src/casts/coercion-passing.rkt
@@ -1,0 +1,330 @@
+#lang typed/racket/base/no-check
+;; Translation of expressions into Coercion-Passing Style
+;; Assumed: (cast-representation) is (Coercion)
+
+(require
+ racket/match
+ "../language/forms.rkt"  ;; IDENTITY, ID-EXPR, ZERO-EXPR
+ "../language/syntax.rkt"
+ "../language/syntax-with-constants.rkt"
+ "./interpret-casts-common.rkt"  ;; apply-code
+ )
+;; next-uid! from ../unique-identifiers.rkt
+
+(provide coercion-passing-trans)
+
+
+(: coercion-passing-trans : Uid Uid -> (CoC3-Expr -> CoC3-Expr))
+(define (coercion-passing-trans #:apply-coercion-uid apply-coercion-uid
+                                #:compose-coercions-uid compose-coercions-uid)
+
+  ;; cf. interpret-casts/coercions
+  (define (apply-coercion [v : CoC3-Expr] [c : CoC3-Expr]) : CoC3-Expr
+    ;; TODO: We're not quite sure what these are:
+    ;; mono-address, base-address, index
+    (let ([mono-address ZERO-EXPR]
+          [base-address ZERO-EXPR]
+          [index ZERO-EXPR])
+      (apply-code apply-coercion-uid v c mono-address base-address index)))
+
+  ;; coercion composition
+  ;; cf. make-compose-coercions in interpret-casts/coercions
+  (: compose-coercions/id/fvs Compose-Coercions-Type)
+  (define (compose-coercions/id/fvs c1 c2)
+    ;; We pass ZERO-EXPR as 3rd/4th arguments. They are dummy, will not
+    ;; be used and should be read as NULL pointer.
+    (apply-code compose-coercions-uid c1 c2 ZERO-EXPR ZERO-EXPR))
+
+  ;; Remove applications of identity coercions
+  (define (apply-coercion-opt [exp : CoC3-Expr] [cont : CoC3-Expr]) : CoC3-Expr
+    ;; If cont K is identity coercion...
+    (if (equal? cont ID-EXPR)
+        exp
+        (apply-coercion exp cont)))
+
+
+  ;; Translate bindings:
+  (: trans-bnd* (CoC3-Bnd* CoC3-Expr -> CoC3-Bnd*))
+  (define (trans-bnd* bnd* cont)
+    (map (lambda ([b : CoC3-Bnd])
+           (cons (car b)
+                 (trans-exp (cdr b) cont)))
+         bnd*))
+
+  ;; Translate values
+  ;; Input ----- V (value)
+  ;; Output ---- Psi(V)
+  (: trans-val (CoC3-Expr -> CoC3-Expr))
+  (define (trans-val val)
+    (match val
+      [(Var _) val]
+      [(Quote _) val]  ;; Literal
+      [(Lambda param* (Castable uid body))
+       ;; next uid for kappa
+       (let ([kappa (next-uid! "kappa")])
+         (Lambda (cons kappa param*)
+                 (Castable uid (trans-exp body (Var kappa)))))]
+      [else (error 'unexpected-val)]))
+
+
+  ;; Translate expressions:
+  ;; Input1 ---- M (expression)
+  ;; Input2 ---- K (continuation coercion)
+  ;; Output ---- M:K (colon trans result)
+  (: trans-exp (CoC3-Expr CoC3-Expr -> CoC3-Expr))
+  (define (trans-exp exp cont)
+    (match exp
+      ;; uncoerced values:
+      [(or (Var _)
+           (Quote _)
+           (Lambda _ (Castable _ _)))
+       (apply-coercion-opt (trans-val exp) cont)]
+
+      ;; App:
+      [(App-Fn-or-Proxy cast compose e0 e*)
+       (App-Fn-or-Proxy
+        cast
+        compose
+        (trans-exp e0 ID-EXPR)
+        (cons cont
+              (map (lambda (e) (trans-exp e ID-EXPR)) e*)))]
+
+      [(Op operator e*)
+       (apply-coercion-opt
+        (Op operator
+            (map (lambda (e) (trans-exp e ID-EXPR)) e*))
+        cont)]
+
+      [(Letrec bnd* body)
+       (Letrec (trans-bnd* bnd* ID-EXPR)
+               (trans-exp body cont))]
+      [(Let bnd* body)
+       (Let (trans-bnd* bnd* ID-EXPR)
+            (trans-exp body cont))]
+
+      ;; observe whether e1 has the given type
+      [(Observe e1 ty) (Observe (trans-exp e1 ID-EXPR) ty)]
+
+      ;; Control-Flow-Forms:
+      [(If e1 e2 e3)
+       (If (trans-exp e1 ID-EXPR)
+           (trans-exp e2 cont)
+           (trans-exp e3 cont))]
+      [(Switch e0 e1 e2)
+       (Switch (trans-exp e0 cont)
+               (for/list [(e e1)]
+                 (cons (car e) (trans-exp (cdr e) cont)))
+               (trans-exp e2 cont))]
+      [(Begin e* e1)
+       (Begin (map (lambda (e) (trans-exp e ID-EXPR)) e*)
+                     (trans-exp e1 cont))]
+      [(Repeat var start end acc ini body)
+       (apply-coercion-opt
+        (Repeat var
+                (trans-exp start ID-EXPR)
+                (trans-exp end ID-EXPR)
+                acc
+                (trans-exp ini ID-EXPR)
+                (trans-exp body ID-EXPR))
+        cont)]
+      [(No-Op)
+       (No-Op)]
+
+      [(Assign name e) ;; name --> variable name string?
+       (apply-coercion-opt
+        (Assign name
+                (trans-exp e ID-EXPR))
+        cont)]
+      [(Global name)
+       (Global name)]
+
+      [(App-Code e0 e*)
+       (match e0
+         [(Code-Label (Uid "apply-coercion" u))
+          ;; e0 ---> (Code-Label (Uid "apply-coercion" 160))
+          ;; e* ---> 1st: target, 2nd: coercion expr
+          (let ([e1 (car e*)]   ;; target exp
+                [c1 (cadr e*)]  ;; coercion
+                [kappa (next-uid! "kappa")])
+            (if (equal? cont ID-EXPR)
+                ;; case: cont is identity coercion
+                (trans-exp e1 c1)
+                ;; otherwise:
+                (Let (list
+                      (cons kappa (compose-coercions/id/fvs c1
+                                                            cont)))
+                     (trans-exp e1 (Var kappa)))))]
+         [(Code-Label (Uid _ _))
+          (apply-coercion-opt
+           (App-Code e0 (for/list ([v e*])
+                          (trans-exp v ID-EXPR)))
+           cont)]
+         [_ (error "e0 is not Code-Label" (pretty-format exp))]
+         )]
+
+      [(Dyn-Immediate-Tag=Huh v type)
+       (if (equal? cont ID-EXPR)
+           (Dyn-Immediate-Tag=Huh (trans-exp v ID-EXPR) type)
+           (begin
+             (pretty-print exp)
+             (pretty-print cont)
+             (error 'cont-not-id-in-trivial)))]
+      [(Dyn-Box-Value v)
+       (if (equal? cont ID-EXPR)
+           (Dyn-Box-Value (trans-exp v ID-EXPR))
+           (begin
+             (pretty-print exp)
+             (pretty-print cont)
+             (error 'cont-not-id-in-trivial)))]
+
+      [(Dyn-Box-Type v)
+       (if (equal? cont ID-EXPR)
+           (Dyn-Box-Type (trans-exp v ID-EXPR))
+           (begin
+             (pretty-print exp)
+             (pretty-print cont)
+             (error 'cont-not-id-in-trivial)))]
+
+      [(Type-Mu-Huh v)
+       (if (equal? cont ID-EXPR)
+           (Type-Mu-Huh (trans-exp v ID-EXPR))
+           (begin
+             (pretty-print exp)
+             (pretty-print cont)
+             (error 'cont-not-id-in-trivial)))]
+      [(Type-Mu-Body v)
+       (if (equal? cont ID-EXPR)
+           (Type-Mu-Body (trans-exp v ID-EXPR))
+           (begin
+             (pretty-print exp)
+             (pretty-print cont)
+             (error 'cont-not-id-in-trivial)))]
+      [(Type-Fn-Huh v)
+       (if (equal? cont ID-EXPR)
+           (Type-Fn-Huh (trans-exp v ID-EXPR))
+           (begin
+             (pretty-print exp)
+             (pretty-print cont)
+             (error 'cont-not-id-in-trivial)))]
+      [(Type-Fn-arity v)
+       (apply-coercion-opt
+        (Type-Fn-arity (trans-exp v ID-EXPR))
+        cont)]
+      [(Type-Fn-arg v1 v2)
+       (apply-coercion-opt
+        (Type-Fn-arg (trans-exp v1 ID-EXPR)
+                     (trans-exp v2 ID-EXPR))
+        cont)]
+      [(Type-Fn-return v)
+       (apply-coercion-opt
+        (Type-Fn-return (trans-exp v ID-EXPR))
+        cont)]
+
+      [(Blame v)
+       (apply-coercion-opt
+        (Blame (trans-exp v ID-EXPR))
+        cont)]
+
+      ;; box (references):
+      [(Unguarded-Box v)
+       (apply-coercion-opt
+        (Unguarded-Box (trans-exp v ID-EXPR))
+        cont)]
+      [(Unguarded-Box-Ref box)
+       (apply-coercion-opt
+        (Unguarded-Box-Ref (trans-exp box ID-EXPR))
+        cont)]
+      [(Unguarded-Box-Set! box v)
+       (apply-coercion-opt
+        (Unguarded-Box-Set! (trans-exp box ID-EXPR) (trans-exp v ID-EXPR))
+        cont)]
+
+      ;; monobox:
+      [(Mbox v ty)
+       (apply-coercion-opt
+        (Mbox (trans-exp v ID-EXPR) ty)
+        cont)]
+      [(Mbox-val-ref e)
+       (apply-coercion-opt
+        (Mbox-val-ref (trans-exp e ID-EXPR))
+        cont)]
+      [(Mbox-val-set! e1 e2)
+       (apply-coercion-opt
+        (Mbox-val-set! (trans-exp e1 ID-EXPR) (trans-exp e2 ID-EXPR))
+        cont)]
+      [(Mbox-rtti-ref e)
+       (apply-coercion-opt
+        (Mbox-rtti-ref (trans-exp e ID-EXPR))
+        cont)]
+
+      ;; vectors:
+      [(Unguarded-Vect e1 e2)
+       (apply-coercion-opt
+        (Unguarded-Vect (trans-exp e1 ID-EXPR) (trans-exp e2 ID-EXPR))
+        cont)]
+      [(Unguarded-Vect-Ref e1 e2)
+       (apply-coercion-opt
+        (Unguarded-Vect-Ref (trans-exp e1 ID-EXPR) (trans-exp e2 ID-EXPR))
+        cont)]
+      [(Unguarded-Vect-Set! v1 v2 v3)
+       (apply-coercion-opt
+        (Unguarded-Vect-Set! (trans-exp v1 ID-EXPR) (trans-exp v2 ID-EXPR) (trans-exp v3 ID-EXPR))
+        cont)]
+      [(Unguarded-Vect-length v)
+       (apply-coercion-opt
+        (Unguarded-Vect-length (trans-exp v ID-EXPR))
+        cont)]
+
+      ;; proxied reference coercions:
+      [(Ref-Coercion-Read e)
+       (apply-coercion-opt
+        (Ref-Coercion-Read (trans-exp e ID-EXPR))
+        cont)]
+      [(Ref-Coercion-Write e)
+       (apply-coercion-opt
+        (Ref-Coercion-Write (trans-exp e ID-EXPR))
+        cont)]
+
+      ;; tuples:
+      [(Create-tuple e*)
+       (apply-coercion-opt
+        (Create-tuple
+         (for/list ([a e*])
+           (trans-exp a ID-EXPR)))
+        cont)]
+      [(Tuple-proj e1 e2)
+       (apply-coercion-opt
+        (Tuple-proj (trans-exp e1 ID-EXPR) (trans-exp e2 ID-EXPR))
+        cont)]
+
+      ;; proxies:
+      [(Guarded-Proxy-Huh v)
+       (apply-coercion-opt
+        (Guarded-Proxy-Huh (trans-exp v ID-EXPR))
+        cont)]
+      [(Guarded-Proxy-Ref v)
+       (apply-coercion-opt
+        (Guarded-Proxy-Ref (trans-exp v ID-EXPR))
+        cont)]
+      [(Guarded-Proxy-Coercion v)
+       (apply-coercion-opt
+        (Guarded-Proxy-Coercion (trans-exp v ID-EXPR))
+        cont)]
+
+      [(Type v)
+       (Type v)]
+
+      [(Quote-Coercion c)
+       (Quote-Coercion c)]
+      [(Sequence-Coercion e1 e2)
+       (Sequence-Coercion e1 e2)]
+      [(Project-Coercion e1 e2)
+       (Project-Coercion e1 e2)]
+
+      ;; forms whose translations are unimplemented:
+      [_ (pretty-print exp)
+         (error 'todo-no-case)]
+      ))
+
+  ;; Translate toplevel expressions with identity continuation coercion:
+  (lambda (exp) (trans-exp exp ID-EXPR)))

--- a/src/casts/coercion-passing.rkt
+++ b/src/casts/coercion-passing.rkt
@@ -141,17 +141,13 @@
          [(Code-Label (Uid "apply-coercion" u))
           ;; e0 ---> (Code-Label (Uid "apply-coercion" 160))
           ;; e* ---> 1st: target, 2nd: coercion expr
-          (let ([e1 (car e*)]   ;; target exp
-                [c1 (cadr e*)]  ;; coercion
-                [kappa (next-uid! "kappa")])
+          (let ([e1 (car e*)]    ;; target exp
+                [c1 (cadr e*)])  ;; coercion
             (if (equal? cont ID-EXPR)
                 ;; case: cont is identity coercion
                 (trans-exp e1 c1)
                 ;; otherwise:
-                (Let (list
-                      (cons kappa (compose-coercions/id/fvs c1
-                                                            cont)))
-                     (trans-exp e1 (Var kappa)))))]
+                (trans-exp e1 (compose-coercions/id/fvs c1 cont))))]
          [(Code-Label (Uid _ _))
           (apply-coercion-opt
            (App-Code e0 (for/list ([v e*])

--- a/src/casts/coercion-passing.rkt
+++ b/src/casts/coercion-passing.rkt
@@ -298,8 +298,8 @@
        (Project-Coercion e1 e2)]
 
       ;; forms whose translations are unimplemented:
-      [_ (pretty-print exp)
-         (error 'todo-no-case)]
+      ;; [_ (pretty-print exp)
+      ;;    (error 'todo-no-case)]
       ))
 
   ;; Translate toplevel expressions with identity continuation coercion:

--- a/src/casts/coercion-passing.rkt
+++ b/src/casts/coercion-passing.rkt
@@ -161,49 +161,31 @@
          )]
 
       [(Dyn-Immediate-Tag=Huh v type)
-       (if (equal? cont ID-EXPR)
-           (Dyn-Immediate-Tag=Huh (trans-exp v ID-EXPR) type)
-           (begin
-             (pretty-print exp)
-             (pretty-print cont)
-             (error 'cont-not-id-in-trivial)))]
+       (apply-coercion-opt
+        (Dyn-Immediate-Tag=Huh (trans-exp v ID-EXPR) type)
+        cont)]
       [(Dyn-Box-Value v)
-       (if (equal? cont ID-EXPR)
-           (Dyn-Box-Value (trans-exp v ID-EXPR))
-           (begin
-             (pretty-print exp)
-             (pretty-print cont)
-             (error 'cont-not-id-in-trivial)))]
-
+       (apply-coercion-opt
+        (Dyn-Box-Value (trans-exp v ID-EXPR))
+        cont)]
       [(Dyn-Box-Type v)
-       (if (equal? cont ID-EXPR)
-           (Dyn-Box-Type (trans-exp v ID-EXPR))
-           (begin
-             (pretty-print exp)
-             (pretty-print cont)
-             (error 'cont-not-id-in-trivial)))]
+       (apply-coercion-opt
+        (Dyn-Box-Type (trans-exp v ID-EXPR))
+        cont)]
 
       [(Type-Mu-Huh v)
-       (if (equal? cont ID-EXPR)
-           (Type-Mu-Huh (trans-exp v ID-EXPR))
-           (begin
-             (pretty-print exp)
-             (pretty-print cont)
-             (error 'cont-not-id-in-trivial)))]
+       (apply-coercion-opt
+        (Type-Mu-Huh (trans-exp v ID-EXPR))
+        cont)]
       [(Type-Mu-Body v)
-       (if (equal? cont ID-EXPR)
-           (Type-Mu-Body (trans-exp v ID-EXPR))
-           (begin
-             (pretty-print exp)
-             (pretty-print cont)
-             (error 'cont-not-id-in-trivial)))]
+       (apply-coercion-opt
+        (Type-Mu-Body (trans-exp v ID-EXPR))
+        cont)]
+
       [(Type-Fn-Huh v)
-       (if (equal? cont ID-EXPR)
-           (Type-Fn-Huh (trans-exp v ID-EXPR))
-           (begin
-             (pretty-print exp)
-             (pretty-print cont)
-             (error 'cont-not-id-in-trivial)))]
+       (apply-coercion-opt
+        (Type-Fn-Huh (trans-exp v ID-EXPR))
+        cont)]
       [(Type-Fn-arity v)
        (apply-coercion-opt
         (Type-Fn-arity (trans-exp v ID-EXPR))

--- a/src/casts/convert-closures.rkt
+++ b/src/casts/convert-closures.rkt
@@ -619,7 +619,7 @@ TODO We can generate better code in this pass for function casts.
                  (define closure (next-uid! "closure-field"))
                  (define coercion (next-uid! "coercion-field"))
                  (match-define (Closure _ _ _ label _ caster? _ p* _)
-                   (make-apply-casted-closure! (if (enable-crcps?) (+ i 1) i) cast compose))
+                   (make-apply-casted-closure! (if (enable-tail-coercion-composition?) (+ i 1) i) cast compose))
                  (Let (list (cons closure clos) (cons coercion crcn))
                    (Let-Closures
                     ;; The layout of this closure is very specific
@@ -1191,14 +1191,14 @@ TODO We can generate better code in this pass for function casts.
   (define-values (v* b*)
     (for/lists ([v* : (Listof (Var Uid))]
                 [b* : (Bnd* CoC5-Expr)])
-               ([arg (if (enable-crcps?) (cdr arg*) arg*)]
+               ([arg (if (enable-tail-coercion-composition?) (cdr arg*) arg*)]
                 [i (in-naturals)])
       (define u (next-uid! (format "fn-cast-arg~a" i)))
       (define arg-crcn (Fn-Coercion-Arg crcn (Quote i)))
       (define args (list arg arg-crcn top-level?))
       (values (Var u) (cons u (App-Code cast-cl args)))))
   (cond
-   [(enable-crcps?)
+   [(enable-tail-coercion-composition?)
     (define passed-crcn (car arg*))
     (define composed-crcn (App-Code compose-cl (list (Fn-Coercion-Return crcn) passed-crcn ZERO-EXPR ZERO-EXPR)))
     (define clos-app (Closure-App (Closure-Code fun) fun (cons composed-crcn v*)))

--- a/src/casts/convert-closures.rkt
+++ b/src/casts/convert-closures.rkt
@@ -619,7 +619,7 @@ TODO We can generate better code in this pass for function casts.
                  (define closure (next-uid! "closure-field"))
                  (define coercion (next-uid! "coercion-field"))
                  (match-define (Closure _ _ _ label _ caster? _ p* _)
-                   (make-apply-casted-closure! (if (enable-crcps?) (+ i 1) i) cast))
+                   (make-apply-casted-closure! (if (enable-crcps?) (+ i 1) i) cast compose))
                  (Let (list (cons closure clos) (cons coercion crcn))
                    (Let-Closures
                     ;; The layout of this closure is very specific

--- a/src/casts/convert-closures.rkt
+++ b/src/casts/convert-closures.rkt
@@ -1188,7 +1188,6 @@ TODO We can generate better code in this pass for function casts.
   (define cast-cl (Code-Label cast-uid))
   (define compose-cl (Code-Label compose-uid))
   (define top-level? (Quote #t))
-  (define index ZERO-EXPR)
   (define-values (v* b*)
     (for/lists ([v* : (Listof (Var Uid))]
                 [b* : (Bnd* CoC5-Expr)])

--- a/src/casts/interpret-casts-common.rkt
+++ b/src/casts/interpret-casts-common.rkt
@@ -474,7 +474,7 @@ TODO write unit tests
           [uid? uid?]
           [else
            (define-values (uid code)
-             (build-caster! (if (enable-crcps?) (- arity 1) arity)))
+             (build-caster! (if (enable-tail-coercion-composition?) (- arity 1) arity)))
            (add-cast-runtime-binding! uid code)
            (hash-set! fn-cast-uid-map arity uid)  ;; Should be decremented, too?
            uid])))

--- a/src/casts/interpret-casts-common.rkt
+++ b/src/casts/interpret-casts-common.rkt
@@ -364,6 +364,7 @@ TODO write unit tests
 ;; The casted is attatched to the proxy
 (define ((make-build-caster/coercions
           #:apply-coercion-uid [apply-coercion-uid : Uid]
+          #:compose-coercions-uid [compose-coercions-uid : Uid]
           #:compose-coercions  [compose-coercions : Compose-Coercions-Type]
           #:id-coercion-huh    [id-coercion-huh : Id-Coercion-Huh-Type])
          [arity : Nat])
@@ -452,11 +453,11 @@ TODO write unit tests
                      ;; If so the original closure is the correct type
                      raw-clos
                      ;; Otherwise a new proxy is needed
-                     (Fn-Proxy (list #{arity :: Index} apply-coercion-uid)
+                     (Fn-Proxy (list #{arity :: Index} apply-coercion-uid compose-coercions-uid)
                                raw-clos
                                (new-fn-crcn t1 t2 arity arg* ret)))))
              ;; Closure is unproxied --> just make a new proxy
-             (Fn-Proxy (list #{arity :: Index} apply-coercion-uid) fun crcn))))))
+             (Fn-Proxy (list #{arity :: Index} apply-coercion-uid compose-coercions-uid) fun crcn))))))
   (values casting-code-name casting-code))
 
 (: make-fn-cast-helpers : (Nat -> (Values Uid CoC3-Code)) -> (Nat -> Uid))
@@ -472,9 +473,10 @@ TODO write unit tests
         (cond
           [uid? uid?]
           [else
-           (define-values (uid code) (build-caster! arity))
+           (define-values (uid code)
+             (build-caster! (if (enable-crcps?) (- arity 1) arity)))
            (add-cast-runtime-binding! uid code)
-           (hash-set! fn-cast-uid-map arity uid)
+           (hash-set! fn-cast-uid-map arity uid)  ;; Should be decremented, too?
            uid])))
     get-fn-cast!)
 

--- a/src/casts/interpret-casts-with-coercions.rkt
+++ b/src/casts/interpret-casts-with-coercions.rkt
@@ -691,7 +691,7 @@ form, to the shortest branch of the cast tree that is relevant.
       [(id-coercion?$ c1)
        (if (id-coercion?$ c2)
            (Quote '())
-           (if (enable-crcps?)
+           (if (enable-tail-coercion-composition?)
                (when$ (not$ (op$ = (Quote 0) ret-id?)) (Unguarded-Box-Set! ret-id? (Quote #f)))
                (Unguarded-Box-Set! ret-id? (Quote #f))))
        c2]
@@ -706,13 +706,13 @@ form, to the shortest branch of the cast tree that is relevant.
          (cond$
           [(prj-coercion?$ seq_fst)
            (let*$ ([comp_seq_snd (compose-coercions seq_snd c2 ret-id? ret-fvs)])
-             (if (enable-crcps?)
+             (if (enable-tail-coercion-composition?)
                  (when$ (not$ (op$ = (Quote 0) ret-id?)) (Unguarded-Box-Set! ret-id? (Quote #f)))
                  (Unguarded-Box-Set! ret-id? (Quote #f)))
              (seq-coercion$ seq_fst comp_seq_snd))]
           ;; We have to prioritize failure on the right over injection
           [(failed-coercion?$ c2)
-           (if (enable-crcps?)
+           (if (enable-tail-coercion-composition?)
                (when$ (not$ (op$ = (Quote 0) ret-id?)) (Unguarded-Box-Set! ret-id? (Quote #f)))
                (Unguarded-Box-Set! ret-id? (Quote #f)))
            c2]
@@ -737,7 +737,7 @@ form, to the shortest branch of the cast tree that is relevant.
       [(seq-coercion?$ c2)
        (cond$
         [(failed-coercion?$ c1)
-         (if (enable-crcps?)
+         (if (enable-tail-coercion-composition?)
              (when$ (not$ (op$ = (Quote 0) ret-id?)) (Unguarded-Box-Set! ret-id? (Quote #f)))
              (Unguarded-Box-Set! ret-id? (Quote #f)))
          c1]
@@ -746,14 +746,14 @@ form, to the shortest branch of the cast tree that is relevant.
          (let*$ ([seq_fst (seq-coercion-fst$ c2)]
                  [seq_snd (seq-coercion-snd$ c2)]
                  [comp_c1_final (compose-coercions c1 seq_fst ret-id? ret-fvs)])
-           (if (enable-crcps?)
+           (if (enable-tail-coercion-composition?)
                (when$ (not$ (op$ = (Quote 0) ret-id?)) (Unguarded-Box-Set! ret-id? (Quote #f)))
                (Unguarded-Box-Set! ret-id? (Quote #f)))
            (seq-coercion$ comp_c1_final seq_snd))])]
       ;; All Branches from here out will have to check if c2 is failure
       ;; so we do it once to eliminate the possibility
       [(failed-coercion?$ c2)
-       (if (enable-crcps?)
+       (if (enable-tail-coercion-composition?)
            (when$ (not$ (op$ = (Quote 0) ret-id?)) (Unguarded-Box-Set! ret-id? (Quote #f)))
            (Unguarded-Box-Set! ret-id? (Quote #f)))
        (If (failed-coercion?$ c1)
@@ -868,7 +868,7 @@ form, to the shortest branch of the cast tree that is relevant.
   (: compile-lambda Lambda-Type)
   (define (compile-lambda fml* e)
     (define arity (length fml*))
-    (define ctr (get-fn-cast! (if (enable-crcps?) (+ 1 arity) arity)))
+    (define ctr (get-fn-cast! (if (enable-tail-coercion-composition?) (+ 1 arity) arity)))
     (Lambda fml* (Castable ctr (cast-profile/max-function-chain$ e))))
   
   (: compile-app App-Type)

--- a/src/casts/interpret-casts-with-coercions.rkt
+++ b/src/casts/interpret-casts-with-coercions.rkt
@@ -691,7 +691,9 @@ form, to the shortest branch of the cast tree that is relevant.
       [(id-coercion?$ c1)
        (if (id-coercion?$ c2)
            (Quote '())
-           (Unguarded-Box-Set! ret-id? (Quote #f)))         
+           (if (enable-crcps?)
+               (when$ (not$ (op$ = (Quote 0) ret-id?)) (Unguarded-Box-Set! ret-id? (Quote #f)))
+               (Unguarded-Box-Set! ret-id? (Quote #f))))
        c2]
       [(id-coercion?$ c2)
        ;; We know that c1 isn't id because of the test above
@@ -704,11 +706,15 @@ form, to the shortest branch of the cast tree that is relevant.
          (cond$
           [(prj-coercion?$ seq_fst)
            (let*$ ([comp_seq_snd (compose-coercions seq_snd c2 ret-id? ret-fvs)])
-             (Unguarded-Box-Set! ret-id? (Quote #f))
+             (if (enable-crcps?)
+                 (when$ (not$ (op$ = (Quote 0) ret-id?)) (Unguarded-Box-Set! ret-id? (Quote #f)))
+                 (Unguarded-Box-Set! ret-id? (Quote #f)))
              (seq-coercion$ seq_fst comp_seq_snd))]
           ;; We have to prioritize failure on the right over injection
           [(failed-coercion?$ c2)
-           (Unguarded-Box-Set! ret-id? (Quote #f))
+           (if (enable-crcps?)
+               (when$ (not$ (op$ = (Quote 0) ret-id?)) (Unguarded-Box-Set! ret-id? (Quote #f)))
+               (Unguarded-Box-Set! ret-id? (Quote #f)))
            c2]
           ;; Because of the typeing rule for coercions we know that
           ;; c2 must be a (I?;i) aka projection sequence because
@@ -731,19 +737,25 @@ form, to the shortest branch of the cast tree that is relevant.
       [(seq-coercion?$ c2)
        (cond$
         [(failed-coercion?$ c1)
-         (Unguarded-Box-Set! ret-id? (Quote #f))
+         (if (enable-crcps?)
+             (when$ (not$ (op$ = (Quote 0) ret-id?)) (Unguarded-Box-Set! ret-id? (Quote #f)))
+             (Unguarded-Box-Set! ret-id? (Quote #f)))
          c1]
         [else
          ;; must be c1 & (g;I?)
          (let*$ ([seq_fst (seq-coercion-fst$ c2)]
                  [seq_snd (seq-coercion-snd$ c2)]
                  [comp_c1_final (compose-coercions c1 seq_fst ret-id? ret-fvs)])
-           (Unguarded-Box-Set! ret-id? (Quote #f))
+           (if (enable-crcps?)
+               (when$ (not$ (op$ = (Quote 0) ret-id?)) (Unguarded-Box-Set! ret-id? (Quote #f)))
+               (Unguarded-Box-Set! ret-id? (Quote #f)))
            (seq-coercion$ comp_c1_final seq_snd))])]
       ;; All Branches from here out will have to check if c2 is failure
       ;; so we do it once to eliminate the possibility
       [(failed-coercion?$ c2)
-       (Unguarded-Box-Set! ret-id? (Quote #f))
+       (if (enable-crcps?)
+           (when$ (not$ (op$ = (Quote 0) ret-id?)) (Unguarded-Box-Set! ret-id? (Quote #f)))
+           (Unguarded-Box-Set! ret-id? (Quote #f)))
        (If (failed-coercion?$ c1)
            c1
            c2)]

--- a/src/casts/interpret-casts-with-coercions.rkt
+++ b/src/casts/interpret-casts-with-coercions.rkt
@@ -832,7 +832,7 @@ form, to the shortest branch of the cast tree that is relevant.
   ;; For now we are not even trying to be good at compiling coercion composition
   (values compose-coercions-uid compose-coercions/id/fvs))
 
-(: interpret-casts/coercions : -> (C0-Expr -> CoC3-Expr))
+(: interpret-casts/coercions : -> (C0-Expr -> (Values CoC3-Expr Uid Uid)))
 (define (interpret-casts/coercions)
   (define greatest-lower-bound (make-compile-types-greatest-lower-bound))
   (define-values (compile-make-coercion compile-make-med-coercion)
@@ -849,17 +849,19 @@ form, to the shortest branch of the cast tree that is relevant.
     (make-fn-cast-helpers
      (make-build-caster/coercions
       #:apply-coercion-uid apply-coercion-uid
+      #:compose-coercions-uid compose-coercions-uid
       #:compose-coercions compose-coercions
       #:id-coercion-huh   Id-Coercion-Huh)))
   
   (: compile-lambda Lambda-Type)
   (define (compile-lambda fml* e)
-    (define ctr (get-fn-cast! (length fml*)))
+    (define arity (length fml*))
+    (define ctr (get-fn-cast! (if (enable-crcps?) (+ 1 arity) arity)))
     (Lambda fml* (Castable ctr (cast-profile/max-function-chain$ e))))
   
   (: compile-app App-Type)
   (define (compile-app e e*)
-    (App-Fn-or-Proxy apply-coercion-uid e e*))
+    (App-Fn-or-Proxy apply-coercion-uid compose-coercions-uid e e*))
   
   (define compile-fn-cast/coercions
     (make-compile-fn-cast/coercions
@@ -1076,30 +1078,33 @@ form, to the shortest branch of the cast tree that is relevant.
      #:mbox-ref mbox-ref #:mbox-set mbox-set!
      #:mvec-ref mvec-ref #:mvec-set mvec-set!))
   
-  (make-map-expr
-   #:compile-cast    compile-cast
-   #:compile-lambda  compile-lambda
-   #:compile-app     compile-app
-   #:pbox-ref        pbox-ref
-   #:pbox-set        pbox-set!
-   #:pvec-ref        pvec-ref
-   #:pvec-set        pvec-set!
-   #:pvec-len        pvec-len
-   #:mbox-ref        mbox-ref
-   #:mbox-set        mbox-set!
-   #:mvec-ref        mvec-ref
-   #:mvec-set        mvec-set!
-   #:dyn-pbox-ref    dyn-pbox-ref
-   #:dyn-pbox-set    dyn-pbox-set!
-   #:dyn-pvec-ref    dyn-pvec-ref
-   #:dyn-pvec-set    dyn-pvec-set!
-   #:dyn-pvec-len    dyn-pvec-len
-   #:dyn-mbox-ref    dyn-mbox-ref
-   #:dyn-mbox-set    dyn-mbox-set!
-   #:dyn-mvec-ref    dyn-mvec-ref
-   #:dyn-mvec-set    dyn-mvec-set!
-   #:dyn-fn-app      dyn-fn-app
-   #:dyn-tup-prj     dyn-tup-prj))
+  (values
+   (make-map-expr
+    #:compile-cast    compile-cast
+    #:compile-lambda  compile-lambda
+    #:compile-app     compile-app
+    #:pbox-ref        pbox-ref
+    #:pbox-set        pbox-set!
+    #:pvec-ref        pvec-ref
+    #:pvec-set        pvec-set!
+    #:pvec-len        pvec-len
+    #:mbox-ref        mbox-ref
+    #:mbox-set        mbox-set!
+    #:mvec-ref        mvec-ref
+    #:mvec-set        mvec-set!
+    #:dyn-pbox-ref    dyn-pbox-ref
+    #:dyn-pbox-set    dyn-pbox-set!
+    #:dyn-pvec-ref    dyn-pvec-ref
+    #:dyn-pvec-set    dyn-pvec-set!
+    #:dyn-pvec-len    dyn-pvec-len
+    #:dyn-mbox-ref    dyn-mbox-ref
+    #:dyn-mbox-set    dyn-mbox-set!
+    #:dyn-mvec-ref    dyn-mvec-ref
+    #:dyn-mvec-set    dyn-mvec-set!
+    #:dyn-fn-app      dyn-fn-app
+    #:dyn-tup-prj     dyn-tup-prj)
+   apply-coercion-uid
+   compose-coercions-uid))
 
 
 

--- a/src/casts/interpret-casts.rkt
+++ b/src/casts/interpret-casts.rkt
@@ -9,7 +9,8 @@
  "./interpret-casts-with-type-based-casts.rkt"
  "./interpret-casts-with-coercions.rkt"
  "./interpret-casts-with-hyper-coercions.rkt"
- "./interpret-casts-with-error.rkt")
+ "./interpret-casts-with-error.rkt"
+ "./coercion-passing.rkt")
 
 (provide
  interpret-casts)
@@ -28,7 +29,21 @@
     (define ic-expr! : (C0-Expr -> CoC3-Expr)
       (case (cast-representation)
         [(|Type-Based Casts|) (interpret-casts/type-based-casts)]
-        [(Coercions) (interpret-casts/coercions)]
+        [(Coercions)
+         (cond
+          [(enable-crcps?)
+           ;; avoid removing id coercions around injection/projection:
+           (optimize-first-order-coercions? #f)  ; should be parameterize?
+           (define-values (icc apply-coercion-uid compose-coercions-uid)
+             (interpret-casts/coercions))
+           (compose1 (coercion-passing-trans #:apply-coercion-uid apply-coercion-uid
+                                             #:compose-coercions-uid compose-coercions-uid)
+                     icc)]
+          [else
+           (optimize-first-order-coercions? #t)  ; should be parameterize?
+           (define-values (icc apply-coercion-uid compose-coercions-uid)
+             (interpret-casts/coercions))
+           icc])]
         [(Hyper-Coercions) (interpret-casts/hyper-coercions)]
         [(Static) (interpret-casts/error)]
         [else (error 'grift/interpret-casts

--- a/src/casts/interpret-casts.rkt
+++ b/src/casts/interpret-casts.rkt
@@ -32,15 +32,12 @@
         [(Coercions)
          (cond
           [(enable-crcps?)
-           ;; avoid removing id coercions around injection/projection:
-           (optimize-first-order-coercions? #f)  ; should be parameterize?
            (define-values (icc apply-coercion-uid compose-coercions-uid)
              (interpret-casts/coercions))
            (compose1 (coercion-passing-trans #:apply-coercion-uid apply-coercion-uid
                                              #:compose-coercions-uid compose-coercions-uid)
                      icc)]
           [else
-           (optimize-first-order-coercions? #t)  ; should be parameterize?
            (define-values (icc apply-coercion-uid compose-coercions-uid)
              (interpret-casts/coercions))
            icc])]
@@ -49,8 +46,13 @@
         [else (error 'grift/interpret-casts
                      "unexpected cast representation: ~a"
                      (cast-representation))]))
-    
-    (define new-e (ic-expr! e))
+
+    (define new-e
+      (cond [(enable-crcps?)
+             ;; avoid removing id coercions around injection/projection:
+             (parameterize ([optimize-first-order-coercions? #f])
+               (ic-expr! e))]
+             [else (ic-expr! e)]))
     
     (define rt-bindings  (cast-runtime-code-bindings))
     (define rt-constants : (Option CoC3-Bnd*)

--- a/src/casts/interpret-casts.rkt
+++ b/src/casts/interpret-casts.rkt
@@ -31,7 +31,7 @@
         [(|Type-Based Casts|) (interpret-casts/type-based-casts)]
         [(Coercions)
          (cond
-          [(enable-crcps?)
+          [(enable-tail-coercion-composition?)
            (define-values (icc apply-coercion-uid compose-coercions-uid)
              (interpret-casts/coercions))
            (compose1 (coercion-passing-trans #:apply-coercion-uid apply-coercion-uid
@@ -48,7 +48,7 @@
                      (cast-representation))]))
 
     (define new-e
-      (cond [(enable-crcps?)
+      (cond [(enable-tail-coercion-composition?)
              ;; avoid removing id coercions around injection/projection:
              (parameterize ([optimize-first-order-coercions? #f])
                (ic-expr! e))]

--- a/src/casts/purify-letrec.rkt
+++ b/src/casts/purify-letrec.rkt
@@ -82,7 +82,7 @@
      (and (> depth 0) (simple? e uid* (+ 1 depth) #t))]
     [(App-Fn e e*) 
      (and outer-lambda? (recur e) (recur* e*))]
-    [(App-Fn-or-Proxy u e e*)
+    [(App-Fn-or-Proxy u1 u2 e e*)
      (and outer-lambda? (recur e) (recur* e*))]
     [(App-Code e e*)
      (and outer-lambda? (recur e) (recur* e*))]

--- a/src/configuration.rkt
+++ b/src/configuration.rkt
@@ -91,3 +91,8 @@
 
 
 (define with-contracts : (Parameterof Boolean)  (make-parameter #f))
+
+
+;; Toggle coercion-passing style translation
+(define enable-crcps? : (Parameterof Boolean)
+  (make-parameter #f))

--- a/src/configuration.rkt
+++ b/src/configuration.rkt
@@ -94,5 +94,5 @@
 
 
 ;; Toggle coercion-passing style translation
-(define enable-crcps? : (Parameterof Boolean)
+(define enable-tail-coercion-composition? : (Parameterof Boolean)
   (make-parameter #f))

--- a/src/language/forms.rkt
+++ b/src/language/forms.rkt
@@ -233,7 +233,11 @@ And a type constructor "name" expecting the types of field1 and field2
   (App-Code rand rators)
   (App-Fn rand rators)
   (App/Fn-Proxy-Huh rand rators)
-  (App-Fn-or-Proxy cast rand rators)
+  ;; cast:    Uid of apply-coercion
+  ;; compose: Uid of compose-coercions
+  ;; (cast and compose are necessary in cast-apply-cast in convert-closures)
+  ;; rand for operand; rators for operators.
+  (App-Fn-or-Proxy cast compose rand rators)
   ;; Benchmarking tools language forms
   ;; low cost repetition
   (Repeat var start end acc init body)


### PR DESCRIPTION
This pull request adds [coercion-passing style translation](https://wgt20.irif.fr/wgt20-final25-acmpaginated.pdf).

Coercion-passing style translation is toggled on, when command-line option `--crcps` is specified. (A new parameter `enable-crcps?` is introduced in `configuation.rkt`.)

Though I need some more adjustment, I'd like you to see our changes first. I'll answer your questions.