### PR TITLE
Typo fixes in `tests/suite/program/lib.grift`

### DIFF
--- a/tests/suite/program/lib.grift
+++ b/tests/suite/program/lib.grift
@@ -57,7 +57,7 @@
           : ((GVect Dyn) -> ())
           (lambda (l)
             (gvector-list-destruct l
-             (lambda ([v : (GVect Dyn)] [i : Int] [s : Int])
+             (lambda ([v : (GVect Dyn)] [i : Int] [m : Int])
                (if (= i m) 
                     (gvector-set! l 0 (gvector-double v))
                     ()))))]
@@ -71,10 +71,10 @@
                  (gvector-set! v i e)
                  (gvector-set! l 2 (add1 i))
                  ()))))]
-         
+        
          [add1 (lambda ([x : Int]) (+ x 1))]
-         [zero? (lambda ([x : Int] (= 0 x)))]
-         [])
+         [zero? (lambda ([x : Int]) (= 0 x))]
+         )
   ())
          
                          


### PR DESCRIPTION
Maybe I'm misunderstanding your test runner, I'm a little bit unclear on how this could have _ever_ run: it has an unbound variable, a syntax error in the lambda, and an empty letrec binding (?!).