### PR TITLE
Fixed Tuple-proj cast insertion with dynamic operations turned off

### DIFF
--- a/src/grift/insert-casts.rkt
+++ b/src/grift/insert-casts.rkt
@@ -434,7 +434,7 @@
         (add-cast! e-src dop)
         dop]
        [else
-        (define n : Index (cast (+ n 1) Index))
+        (define n : Index (add1 (cast i Index)))
         (define tgt-ty : Grift-Type
           (STuple n (make-list n DYN-TYPE)))
         (Tuple-proj (mk-cast e-src l-th e DYN-TYPE tgt-ty) i)])]


### PR DESCRIPTION
Fix for #113.
Note that I changed the behavior a bit: you need to check if `i` is a valid index, and only then add 1 to create a correct cast.